### PR TITLE
ci: add runner availability preflight gate for release packaging

### DIFF
--- a/.github/workflows/_release-workspace-installer-core.yml
+++ b/.github/workflows/_release-workspace-installer-core.yml
@@ -42,8 +42,86 @@ permissions:
   contents: write
 
 jobs:
+  runner_preflight:
+    name: Release Runner Availability Preflight
+    runs-on: ubuntu-latest
+    outputs:
+      reason_code: ${{ steps.check.outputs.reason_code }}
+    steps:
+      - id: check
+        name: Validate eligible self-hosted release runner availability
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $repo = [string]'${{ github.repository }}'
+          $requiredLabels = @('self-hosted', 'windows', 'self-hosted-windows-lv')
+          $reportPath = Join-Path $env:RUNNER_TEMP 'release-runner-availability-preflight.json'
+
+          $runnersJson = & gh api "repos/$repo/actions/runners?per_page=100" 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to list runners for '$repo'. $([string]::Join("`n", @($runnersJson)))"
+          }
+
+          $runnerPayload = $runnersJson | ConvertFrom-Json -ErrorAction Stop
+          $onlineRunners = @()
+          $eligibleRunners = @()
+          foreach ($runner in @($runnerPayload.runners)) {
+            if ([string]$runner.status -ne 'online') {
+              continue
+            }
+
+            $onlineRunners += [string]$runner.name
+            $runnerLabels = @{}
+            foreach ($label in @($runner.labels)) {
+              $runnerLabels[[string]$label.name.ToLowerInvariant()] = $true
+            }
+
+            $missingLabels = @($requiredLabels | Where-Object { -not $runnerLabels.ContainsKey($_) })
+            if ($missingLabels.Count -eq 0) {
+              $eligibleRunners += [ordered]@{
+                name = [string]$runner.name
+                labels = @($runner.labels | ForEach-Object { [string]$_.name })
+              }
+            }
+          }
+
+          $report = [ordered]@{
+            schema_version = '1.0'
+            repository = $repo
+            generated_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+            required_labels = $requiredLabels
+            online_runners = $onlineRunners
+            eligible_runners = $eligibleRunners
+            status = if ($eligibleRunners.Count -gt 0) { 'pass' } else { 'fail' }
+            reason_code = if ($eligibleRunners.Count -gt 0) { 'ok' } else { 'runner_unavailable' }
+            remediation = 'Register at least one online self-hosted runner with labels self-hosted, windows, self-hosted-windows-lv.'
+          }
+
+          $report | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $reportPath -Encoding utf8
+
+          if ($eligibleRunners.Count -gt 0) {
+            "reason_code=ok" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            Write-Host "Runner preflight passed. Eligible runners: $($eligibleRunners.Count)."
+            exit 0
+          }
+
+          "reason_code=runner_unavailable" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          throw "[runner_unavailable] No online runner matched required labels ($($requiredLabels -join ', ')). Remediation: $($report.remediation)"
+
+      - name: Upload runner availability preflight report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-runner-availability-preflight-${{ github.run_id }}
+          path: ${{ runner.temp }}/release-runner-availability-preflight.json
+          if-no-files-found: error
+
   package:
     name: Package Workspace Installer
+    needs: [runner_preflight]
     runs-on: [self-hosted, windows, self-hosted-windows-lv]
     outputs:
       asset_name: ${{ steps.package.outputs.asset_name }}

--- a/tests/WorkspaceInstallerReleaseContract.Tests.ps1
+++ b/tests/WorkspaceInstallerReleaseContract.Tests.ps1
@@ -46,7 +46,14 @@ Describe 'Workspace installer release workflow contract' {
     }
 
     It 'defines package and publish jobs with release asset upload' {
+        $script:coreWorkflowContent | Should -Match 'name:\s*Release Runner Availability Preflight'
+        $script:coreWorkflowContent | Should -Match 'Validate eligible self-hosted release runner availability'
+        $script:coreWorkflowContent | Should -Match 'repos/\$repo/actions/runners\?per_page=100'
+        $script:coreWorkflowContent | Should -Match 'reason_code=runner_unavailable'
+        $script:coreWorkflowContent | Should -Match '\[runner_unavailable\]'
+        $script:coreWorkflowContent | Should -Match 'release-runner-availability-preflight-\$\{\{\s*github\.run_id\s*\}\}'
         $script:coreWorkflowContent | Should -Match 'name:\s*Package Workspace Installer'
+        $script:coreWorkflowContent | Should -Match 'needs:\s*\[runner_preflight\]'
         $script:coreWorkflowContent | Should -Match 'name:\s*Publish GitHub Release Asset'
         $script:coreWorkflowContent | Should -Match 'Release preflight - verify icon-editor upstream pin freshness'
         $script:coreWorkflowContent | Should -Match 'repos/LabVIEW-Community-CI-CD/labview-icon-editor/branches/develop'


### PR DESCRIPTION
## Summary
- add unner_preflight ubuntu job to _release-workspace-installer-core.yml
- check for online runners matching required labels: self-hosted, windows, self-hosted-windows-lv
- emit deterministic failure reason code unner_unavailable with remediation guidance
- gate package job on successful preflight (
eeds: [runner_preflight])
- upload machine-readable preflight artifact for diagnostics

## Contract updates
- extend 	ests/WorkspaceInstallerReleaseContract.Tests.ps1 to require the preflight job and gate wiring

## Validation
- Invoke-Pester -Path ./tests -CI (158/158 passed)