### PR TITLE
feat(ops): local docker package for release control-plane exercise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
             './tests/WatchWorkflowRunContract.Tests.ps1',
             './tests/PortableOpsRuntimeContract.Tests.ps1',
             './tests/VsCodeTasksContract.Tests.ps1',
+            './tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1',
             './tests/UploadArtifactRetryCompositeContract.Tests.ps1',
             './tests/InstallerHarnessWorkflowContract.Tests.ps1',
             './tests/OpsMonitoringWorkflowContract.Tests.ps1',

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,12 @@
       "id": "opsRunId",
       "type": "promptString",
       "description": "Run ID (optional for watch)"
+    },
+    {
+      "id": "opsControlPlaneMode",
+      "type": "promptString",
+      "description": "Release control plane mode",
+      "default": "Validate"
     }
   ],
   "tasks": [
@@ -114,6 +120,27 @@
         "${input:opsBranch}",
         "-OutputPath",
         "artifacts/dispatch/queue-snapshot.json"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "ops: release control plane local (docker)",
+      "type": "shell",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-File",
+        "scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1",
+        "-Repository",
+        "${input:opsRepo}",
+        "-Branch",
+        "${input:opsBranch}",
+        "-Mode",
+        "${input:opsControlPlaneMode}",
+        "-DryRun",
+        "-RunContractTests",
+        "-OutputRoot",
+        "artifacts/release-control-plane-local"
       ],
       "problemMatcher": []
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,7 @@ Build and gate lanes must run in isolated workspaces on every run (`D:\dev` pref
   - `-Mode full` for isolated smoke install validation.
   - `-Watch` to auto-rerun on contract file changes without manual restarts.
 - Use `scripts/Invoke-DockerDesktopLinuxIteration.ps1 -DockerContext desktop-linux` for Docker Desktop Linux command-surface checks (`runner-cli --help`, `runner-cli ppl --help`) before full Windows LabVIEW image runs.
+- Use `scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1` for local containerized release-control-plane exercise (`Validate` + `DryRun` default).
 - If Docker Desktop Linux context is unavailable, confirm `Microsoft-Hyper-V-All`, `VirtualMachinePlatform`, and `Microsoft-Windows-Subsystem-Linux` are enabled, then reboot before retrying.
 - Use `scripts/Test-RunnerCliBundleDeterminism.ps1` and `scripts/Test-WorkspaceInstallerDeterminism.ps1` locally before proposing release-tag publication.
 - Keep local iteration artifacts under `artifacts\release\iteration`.

--- a/README.md
+++ b/README.md
@@ -326,6 +326,25 @@ Control-plane behavior:
 
 `weekly-ops-slo-report.yml` emits machine-readable weekly SLO evidence via `scripts/Write-OpsSloReport.ps1`.
 
+## Local Docker package for control-plane exercise
+
+Run the local Docker harness (safe default, validate + dry-run):
+
+```powershell
+pwsh -NoProfile -File .\scripts\Invoke-ReleaseControlPlaneLocalDocker.ps1 `
+  -Repository LabVIEW-Community-CI-CD/labview-cdev-surface-fork `
+  -Branch main `
+  -Mode Validate `
+  -DryRun `
+  -RunContractTests
+```
+
+This executes `scripts/Exercise-ReleaseControlPlaneLocal.ps1` in the portable ops container image and writes artifacts under:
+- `artifacts\release-control-plane-local`
+
+For offline or container runtime fallback on the host:
+- add `-HostFallback`
+
 Runbook for incidents:
 - `docs/runbooks/release-ops-incident-response.md`
 

--- a/scripts/Cancel-StaleWorkflowRuns.ps1
+++ b/scripts/Cancel-StaleWorkflowRuns.ps1
@@ -25,15 +25,7 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
 
-$allRuns = @(Invoke-GhJson -Arguments @(
-    'run', 'list',
-    '-R', $Repository,
-    '--workflow', $WorkflowFile,
-    '--branch', $Branch,
-    '--event', 'workflow_dispatch',
-    '--limit', '100',
-    '--json', 'databaseId,status,conclusion,url,createdAt,headSha'
-))
+$allRuns = @(Get-GhWorkflowRunsPortable -Repository $Repository -Workflow $WorkflowFile -Branch $Branch -Event 'workflow_dispatch' -Limit 100)
 
 $orderedRuns = @($allRuns | Sort-Object { Parse-RunTimestamp -Run $_ } -Descending)
 $keepIds = @($orderedRuns | Select-Object -First ([Math]::Max($KeepLatestN, 0)) | ForEach-Object { [string]$_.databaseId })

--- a/scripts/Dispatch-WorkflowAtRemoteHead.ps1
+++ b/scripts/Dispatch-WorkflowAtRemoteHead.ps1
@@ -58,15 +58,7 @@ Invoke-Gh -Arguments $dispatchArgs
 
 Start-Sleep -Seconds $DispatchPauseSeconds
 
-$runList = @(Invoke-GhJson -Arguments @(
-    'run', 'list',
-    '-R', $Repository,
-    '--workflow', $WorkflowFile,
-    '--branch', $Branch,
-    '--event', 'workflow_dispatch',
-    '--limit', '30',
-    '--json', 'databaseId,status,conclusion,url,createdAt,headSha,displayTitle'
-))
+$runList = @(Get-GhWorkflowRunsPortable -Repository $Repository -Workflow $WorkflowFile -Branch $Branch -Event 'workflow_dispatch' -Limit 30)
 
 $candidates = @(
     $runList | Where-Object {

--- a/scripts/Exercise-ReleaseControlPlaneLocal.ps1
+++ b/scripts/Exercise-ReleaseControlPlaneLocal.ps1
@@ -1,0 +1,190 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string]$Repository = 'LabVIEW-Community-CI-CD/labview-cdev-surface-fork',
+
+    [Parameter()]
+    [ValidatePattern('^[A-Za-z0-9._/-]+$')]
+    [string]$Branch = 'main',
+
+    [Parameter()]
+    [ValidateSet('Validate', 'CanaryCycle', 'PromotePrerelease', 'PromoteStable', 'FullCycle')]
+    [string]$Mode = 'Validate',
+
+    [Parameter()]
+    [ValidateRange(1, 168)]
+    [int]$SyncGuardMaxAgeHours = 12,
+
+    [Parameter()]
+    [ValidateRange(1, 10)]
+    [int]$KeepLatestCanaryN = 1,
+
+    [Parameter()]
+    [switch]$IncludeOpsAutoRemediation,
+
+    [Parameter()]
+    [switch]$RunContractTests,
+
+    [Parameter()]
+    [switch]$DryRun,
+
+    [Parameter()]
+    [switch]$AllowMutatingModes,
+
+    [Parameter()]
+    [string]$OutputRoot = 'artifacts/release-control-plane-local'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not [string]::Equals($Mode, 'Validate', [System.StringComparison]::OrdinalIgnoreCase) -and -not $AllowMutatingModes) {
+    throw "mutating_mode_blocked: mode '$Mode' requires -AllowMutatingModes."
+}
+
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputRoot))
+if (-not (Test-Path -LiteralPath $resolvedOutputRoot -PathType Container)) {
+    New-Item -Path $resolvedOutputRoot -ItemType Directory -Force | Out-Null
+}
+
+$opsSnapshotScript = Join-Path $PSScriptRoot 'Invoke-OpsMonitoringSnapshot.ps1'
+$opsRemediateScript = Join-Path $PSScriptRoot 'Invoke-OpsAutoRemediation.ps1'
+$controlPlaneScript = Join-Path $PSScriptRoot 'Invoke-ReleaseControlPlane.ps1'
+$sloScript = Join-Path $PSScriptRoot 'Write-OpsSloReport.ps1'
+foreach ($requiredScript in @($opsSnapshotScript, $opsRemediateScript, $controlPlaneScript, $sloScript)) {
+    if (-not (Test-Path -LiteralPath $requiredScript -PathType Leaf)) {
+        throw "required_script_missing: $requiredScript"
+    }
+}
+
+$summary = [ordered]@{
+    schema_version = '1.0'
+    generated_at_utc = (Get-Date).ToUniversalTime().ToString('o')
+    repository = $Repository
+    branch = $Branch
+    mode = $Mode
+    dry_run = [bool]$DryRun
+    allow_mutating_modes = [bool]$AllowMutatingModes
+    output_root = $resolvedOutputRoot
+    status = 'fail'
+    steps = @()
+}
+
+function Add-StepResult {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [string]$Status,
+        [Parameter()]
+        [string]$OutputPath = '',
+        [Parameter()]
+        [string]$Message = ''
+    )
+
+    $step = [ordered]@{
+        name = $Name
+        status = $Status
+        output_path = $OutputPath
+        message = $Message
+    }
+    $summary.steps += @($step)
+}
+
+try {
+    $opsSnapshotPath = Join-Path $resolvedOutputRoot 'ops-monitoring-report.json'
+    & pwsh -NoProfile -File $opsSnapshotScript `
+        -SurfaceRepository $Repository `
+        -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
+        -OutputPath $opsSnapshotPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "ops_snapshot_failed: exit_code=$LASTEXITCODE"
+    }
+    Add-StepResult -Name 'ops_monitoring' -Status 'pass' -OutputPath $opsSnapshotPath
+
+    if ($IncludeOpsAutoRemediation) {
+        $opsRemediatePath = Join-Path $resolvedOutputRoot 'ops-autoremediate-report.json'
+        & pwsh -NoProfile -File $opsRemediateScript `
+            -SurfaceRepository $Repository `
+            -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
+            -OutputPath $opsRemediatePath
+        if ($LASTEXITCODE -ne 0) {
+            throw "ops_autoremediation_failed: exit_code=$LASTEXITCODE"
+        }
+        Add-StepResult -Name 'ops_autoremediate' -Status 'pass' -OutputPath $opsRemediatePath
+    } else {
+        Add-StepResult -Name 'ops_autoremediate' -Status 'skipped' -Message 'IncludeOpsAutoRemediation not set.'
+    }
+
+    $controlPlanePath = Join-Path $resolvedOutputRoot 'release-control-plane-report.json'
+    & pwsh -NoProfile -File $controlPlaneScript `
+        -Repository $Repository `
+        -Branch $Branch `
+        -Mode $Mode `
+        -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
+        -KeepLatestCanaryN $KeepLatestCanaryN `
+        -AutoRemediate:$false `
+        -DryRun:$DryRun `
+        -OutputPath $controlPlanePath
+    if ($LASTEXITCODE -ne 0) {
+        throw "release_control_plane_failed: exit_code=$LASTEXITCODE"
+    }
+    Add-StepResult -Name 'release_control_plane' -Status 'pass' -OutputPath $controlPlanePath
+
+    $sloPath = Join-Path $resolvedOutputRoot 'weekly-ops-slo-report.json'
+    & pwsh -NoProfile -File $sloScript `
+        -SurfaceRepository $Repository `
+        -OutputPath $sloPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "ops_slo_report_failed: exit_code=$LASTEXITCODE"
+    }
+    Add-StepResult -Name 'weekly_ops_slo' -Status 'pass' -OutputPath $sloPath
+
+    if ($RunContractTests) {
+        $pesterOutputPath = Join-Path $resolvedOutputRoot 'control-plane-contract-tests.xml'
+        $pesterPaths = @(
+            (Join-Path $repoRoot 'tests/OpsMonitoringWorkflowContract.Tests.ps1'),
+            (Join-Path $repoRoot 'tests/OpsAutoRemediationWorkflowContract.Tests.ps1'),
+            (Join-Path $repoRoot 'tests/ReleaseControlPlaneWorkflowContract.Tests.ps1'),
+            (Join-Path $repoRoot 'tests/WeeklyOpsSloReportWorkflowContract.Tests.ps1')
+        )
+        $pesterConfig = New-PesterConfiguration
+        $pesterConfig.Run.Path = $pesterPaths
+        $pesterConfig.Run.Exit = $false
+        $pesterConfig.Run.PassThru = $true
+        $pesterConfig.Output.Verbosity = 'Detailed'
+        $pesterConfig.TestResult.Enabled = $true
+        $pesterConfig.TestResult.OutputFormat = 'NUnitXml'
+        $pesterConfig.TestResult.OutputPath = $pesterOutputPath
+        $pesterResult = Invoke-Pester -Configuration $pesterConfig
+        if ($null -eq $pesterResult) {
+            throw 'contract_tests_failed: pester_result_missing'
+        }
+        if ([int]$pesterResult.FailedCount -gt 0 -or [int]$pesterResult.FailedBlocksCount -gt 0) {
+            throw ("contract_tests_failed: failed_count={0}" -f [int]$pesterResult.FailedCount)
+        }
+        Add-StepResult -Name 'contract_tests' -Status 'pass' -OutputPath $pesterOutputPath
+    } else {
+        Add-StepResult -Name 'contract_tests' -Status 'skipped' -Message 'RunContractTests not set.'
+    }
+
+    $summary.status = 'pass'
+}
+catch {
+    Add-StepResult -Name 'harness' -Status 'fail' -Message ([string]$_.Exception.Message)
+    $summary.status = 'fail'
+}
+finally {
+    $summaryPath = Join-Path $resolvedOutputRoot 'release-control-plane-local-summary.json'
+    $summary | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $summaryPath -Encoding utf8
+    Write-Host "Summary written: $summaryPath"
+}
+
+if ([string]$summary.status -ne 'pass') {
+    exit 1
+}
+
+exit 0

--- a/scripts/Invoke-CanarySmokeTagHygiene.ps1
+++ b/scripts/Invoke-CanarySmokeTagHygiene.ps1
@@ -57,13 +57,7 @@ $report = [ordered]@{
 }
 
 try {
-    $releaseList = @(Invoke-GhJson -Arguments @(
-        'release', 'list',
-        '-R', $Repository,
-        '--limit', '200',
-        '--exclude-drafts',
-        '--json', 'tagName,isPrerelease,publishedAt'
-    ))
+    $releaseList = @(Get-GhReleasesPortable -Repository $Repository -Limit 100 -ExcludeDrafts)
     $report.releases_scanned = @($releaseList).Count
 
     $candidates = @()

--- a/scripts/Invoke-ReleaseControlPlane.ps1
+++ b/scripts/Invoke-ReleaseControlPlane.ps1
@@ -168,13 +168,7 @@ function Invoke-ReleaseMode {
     )
 
     $modeConfig = Get-ModeConfig -ModeName $ModeName
-    $releaseList = @(Invoke-GhJson -Arguments @(
-        'release', 'list',
-        '-R', $Repository,
-        '--limit', '200',
-        '--exclude-drafts',
-        '--json', 'tagName,isPrerelease,publishedAt'
-    ))
+    $releaseList = @(Get-GhReleasesPortable -Repository $Repository -Limit 100 -ExcludeDrafts)
 
     $records = @(Get-ReleaseRecordsForDate -ReleaseList $releaseList -DateKey $DateKey)
     $targetRangeRecords = @(

--- a/scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1
+++ b/scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1
@@ -1,0 +1,89 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string]$Repository = 'LabVIEW-Community-CI-CD/labview-cdev-surface-fork',
+
+    [Parameter()]
+    [ValidatePattern('^[A-Za-z0-9._/-]+$')]
+    [string]$Branch = 'main',
+
+    [Parameter()]
+    [ValidateSet('Validate', 'CanaryCycle', 'PromotePrerelease', 'PromoteStable', 'FullCycle')]
+    [string]$Mode = 'Validate',
+
+    [Parameter()]
+    [ValidateRange(1, 168)]
+    [int]$SyncGuardMaxAgeHours = 12,
+
+    [Parameter()]
+    [ValidateRange(1, 10)]
+    [int]$KeepLatestCanaryN = 1,
+
+    [Parameter()]
+    [switch]$IncludeOpsAutoRemediation,
+
+    [Parameter()]
+    [switch]$RunContractTests,
+
+    [Parameter()]
+    [switch]$DryRun,
+
+    [Parameter()]
+    [switch]$AllowMutatingModes,
+
+    [Parameter()]
+    [string]$OutputRoot = 'artifacts/release-control-plane-local',
+
+    [Parameter()]
+    [string]$Image = 'ghcr.io/svelderrainruiz/labview-cdev-surface-ops:v1',
+
+    [Parameter()]
+    [switch]$BuildLocalImage,
+
+    [Parameter()]
+    [string]$LocalTag = 'labview-cdev-surface-ops:local',
+
+    [Parameter()]
+    [switch]$HostFallback
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$portableWrapper = Join-Path $PSScriptRoot 'Invoke-PortableOps.ps1'
+if (-not (Test-Path -LiteralPath $portableWrapper -PathType Leaf)) {
+    throw "portable_wrapper_missing: $portableWrapper"
+}
+
+$scriptArgs = @(
+    '-Repository', $Repository,
+    '-Branch', $Branch,
+    '-Mode', $Mode,
+    '-SyncGuardMaxAgeHours', [string]$SyncGuardMaxAgeHours,
+    '-KeepLatestCanaryN', [string]$KeepLatestCanaryN,
+    '-OutputRoot', $OutputRoot
+)
+if ($IncludeOpsAutoRemediation) {
+    $scriptArgs += '-IncludeOpsAutoRemediation'
+}
+if ($RunContractTests) {
+    $scriptArgs += '-RunContractTests'
+}
+if ($DryRun) {
+    $scriptArgs += '-DryRun'
+}
+if ($AllowMutatingModes) {
+    $scriptArgs += '-AllowMutatingModes'
+}
+
+& $portableWrapper `
+    -ScriptPath 'scripts/Exercise-ReleaseControlPlaneLocal.ps1' `
+    -ScriptArguments $scriptArgs `
+    -Image $Image `
+    -BuildLocalImage:$BuildLocalImage `
+    -LocalTag $LocalTag `
+    -HostFallback:$HostFallback
+
+exit $LASTEXITCODE

--- a/scripts/Watch-WorkflowRun.ps1
+++ b/scripts/Watch-WorkflowRun.ps1
@@ -33,14 +33,7 @@ if ([string]::IsNullOrWhiteSpace($RunId)) {
         throw 'run_id_or_workflow_required: provide -RunId or both -WorkflowFile and -Branch.'
     }
 
-    $latest = @(Invoke-GhJson -Arguments @(
-        'run', 'list',
-        '-R', $Repository,
-        '--workflow', $WorkflowFile,
-        '--branch', $Branch,
-        '--limit', '1',
-        '--json', 'databaseId,url,status,conclusion,createdAt'
-    )) | Select-Object -First 1
+    $latest = @(Get-GhWorkflowRunsPortable -Repository $Repository -Workflow $WorkflowFile -Branch $Branch -Limit 1) | Select-Object -First 1
 
     if ($null -eq $latest) {
         throw 'run_not_found: no workflow runs available to watch.'

--- a/scripts/lib/WorkflowOps.Common.ps1
+++ b/scripts/lib/WorkflowOps.Common.ps1
@@ -98,6 +98,137 @@ function Convert-InputPairsToGhArgs {
     return ,$arguments
 }
 
+function Test-WorkflowRunMatch {
+    param(
+        [Parameter(Mandatory = $true)][object]$Run,
+        [Parameter()][string]$Workflow = ''
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Workflow)) {
+        return $true
+    }
+
+    $token = ([string]$Workflow).Trim().ToLowerInvariant()
+    $runName = ([string]$Run.name).Trim().ToLowerInvariant()
+    $runPath = ([string]$Run.path).Trim().ToLowerInvariant()
+    if ($runName -eq $token) {
+        return $true
+    }
+    if ([string]::IsNullOrWhiteSpace($runPath)) {
+        return $false
+    }
+
+    if ($runPath.Contains($token)) {
+        return $true
+    }
+
+    if (-not $token.EndsWith('.yml') -and -not $token.EndsWith('.yaml')) {
+        if ($runPath.EndsWith("/$token.yml") -or $runPath.EndsWith("/$token.yaml")) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-GhWorkflowRunsPortable {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter()][string]$Workflow = '',
+        [Parameter()][string]$Branch = '',
+        [Parameter()][string]$Event = '',
+        [Parameter()][int]$Limit = 20
+    )
+
+    $safeLimit = [Math]::Max(1, [Math]::Min($Limit, 100))
+    $runsPayload = Invoke-GhJson -Arguments @(
+        'api',
+        "repos/$Repository/actions/runs?per_page=100"
+    )
+    $allRuns = @($runsPayload.workflow_runs)
+    if (@($allRuns).Count -eq 0) {
+        return @()
+    }
+
+    $branchToken = ([string]$Branch).Trim().ToLowerInvariant()
+    $eventToken = ([string]$Event).Trim().ToLowerInvariant()
+    $records = @()
+    foreach ($run in $allRuns) {
+        if (-not (Test-WorkflowRunMatch -Run $run -Workflow $Workflow)) {
+            continue
+        }
+
+        $runBranch = ([string]$run.head_branch).Trim().ToLowerInvariant()
+        if (-not [string]::IsNullOrWhiteSpace($branchToken) -and $runBranch -ne $branchToken) {
+            continue
+        }
+
+        $runEvent = ([string]$run.event).Trim().ToLowerInvariant()
+        if (-not [string]::IsNullOrWhiteSpace($eventToken) -and $runEvent -ne $eventToken) {
+            continue
+        }
+
+        $records += [pscustomobject]@{
+            databaseId = [string]$run.id
+            status = [string]$run.status
+            conclusion = [string]$run.conclusion
+            url = [string]$run.html_url
+            createdAt = [string]$run.created_at
+            updatedAt = [string]$run.updated_at
+            headSha = [string]$run.head_sha
+            event = [string]$run.event
+            workflowName = [string]$run.name
+            displayTitle = [string]$run.display_title
+            headBranch = [string]$run.head_branch
+        }
+    }
+
+    return @(
+        $records |
+            Sort-Object { Parse-RunTimestamp -Run $_ } -Descending |
+            Select-Object -First $safeLimit
+    )
+}
+
+function Get-GhReleasesPortable {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter()][int]$Limit = 30,
+        [Parameter()][switch]$ExcludeDrafts
+    )
+
+    $safeLimit = [Math]::Max(1, [Math]::Min($Limit, 100))
+    $releasePayload = Invoke-GhJson -Arguments @(
+        'api',
+        "repos/$Repository/releases?per_page=100"
+    )
+    $allReleases = @($releasePayload)
+    if (@($allReleases).Count -eq 0) {
+        return @()
+    }
+
+    $records = @()
+    foreach ($release in $allReleases) {
+        $isDraft = [bool]$release.draft
+        if ($ExcludeDrafts -and $isDraft) {
+            continue
+        }
+
+        $records += [pscustomobject]@{
+            tagName = [string]$release.tag_name
+            isPrerelease = [bool]$release.prerelease
+            publishedAt = [string]$release.published_at
+            url = [string]$release.html_url
+            isDraft = $isDraft
+        }
+    }
+
+    return @(
+        $records |
+            Select-Object -First $safeLimit
+    )
+}
+
 function Parse-RunTimestamp {
     param([Parameter(Mandatory = $true)][object]$Run)
 

--- a/tests/CanarySmokeTagHygieneWorkflowContract.Tests.ps1
+++ b/tests/CanarySmokeTagHygieneWorkflowContract.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'Canary smoke tag hygiene workflow contract' {
     }
 
     It 'enforces keep-latest canary tag cleanup behavior' {
-        $script:scriptContent | Should -Match 'release''\s*,\s*''list'''
+        $script:scriptContent | Should -Match 'Get-GhReleasesPortable'
         $script:scriptContent | Should -Match 'release''\s*,\s*''delete'''
         $script:scriptContent | Should -Match '--cleanup-tag'
         $script:scriptContent | Should -Match 'KeepLatestN'

--- a/tests/OpsMonitoringWorkflowContract.Tests.ps1
+++ b/tests/OpsMonitoringWorkflowContract.Tests.ps1
@@ -35,8 +35,9 @@ Describe 'Ops monitoring workflow contract' {
 
     It 'checks runner and sync-guard health with deterministic reason codes' {
         $script:scriptContent | Should -Match 'repos/\$SurfaceRepository/actions/runners\?per_page=100'
-        $script:scriptContent | Should -Match 'run''\s*,\s*''list'''
+        $script:scriptContent | Should -Match 'Get-GhWorkflowRunsPortable'
         $script:scriptContent | Should -Match 'runner_unavailable'
+        $script:scriptContent | Should -Match 'runner_visibility_unavailable'
         $script:scriptContent | Should -Match 'sync_guard_failed'
         $script:scriptContent | Should -Match 'sync_guard_stale'
         $script:scriptContent | Should -Match 'sync_guard_missing'

--- a/tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1
+++ b/tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1
@@ -1,0 +1,44 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Release control plane local Docker harness contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:wrapperPath = Join-Path $script:repoRoot 'scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1'
+        $script:harnessPath = Join-Path $script:repoRoot 'scripts/Exercise-ReleaseControlPlaneLocal.ps1'
+
+        if (-not (Test-Path -LiteralPath $script:wrapperPath -PathType Leaf)) {
+            throw "Local Docker wrapper missing: $script:wrapperPath"
+        }
+        if (-not (Test-Path -LiteralPath $script:harnessPath -PathType Leaf)) {
+            throw "Local Docker harness runtime missing: $script:harnessPath"
+        }
+
+        $script:wrapperContent = Get-Content -LiteralPath $script:wrapperPath -Raw
+        $script:harnessContent = Get-Content -LiteralPath $script:harnessPath -Raw
+    }
+
+    It 'wraps release control plane local harness through portable container runtime' {
+        $script:wrapperContent | Should -Match 'Invoke-PortableOps\.ps1'
+        $script:wrapperContent | Should -Match 'Exercise-ReleaseControlPlaneLocal\.ps1'
+        $script:wrapperContent | Should -Match 'ghcr\.io/svelderrainruiz/labview-cdev-surface-ops:v1'
+        $script:wrapperContent | Should -Match 'BuildLocalImage'
+        $script:wrapperContent | Should -Match 'HostFallback'
+    }
+
+    It 'executes deterministic control-plane local steps and writes summary report' {
+        $script:harnessContent | Should -Match 'Invoke-OpsMonitoringSnapshot\.ps1'
+        $script:harnessContent | Should -Match 'Invoke-OpsAutoRemediation\.ps1'
+        $script:harnessContent | Should -Match 'Invoke-ReleaseControlPlane\.ps1'
+        $script:harnessContent | Should -Match 'Write-OpsSloReport\.ps1'
+        $script:harnessContent | Should -Match 'release-control-plane-local-summary\.json'
+    }
+
+    It 'guards mutating modes unless explicitly allowed' {
+        $script:harnessContent | Should -Match 'mutating_mode_blocked'
+        $script:harnessContent | Should -Match 'AllowMutatingModes'
+        $script:harnessContent | Should -Match 'DryRun'
+    }
+}

--- a/tests/VsCodeTasksContract.Tests.ps1
+++ b/tests/VsCodeTasksContract.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'VS Code tasks contract for portable workflow ops' {
         $script:labels | Should -Contain 'ops: cancel stale runs (portable)'
         $script:labels | Should -Contain 'ops: watch run (portable)'
         $script:labels | Should -Contain 'ops: runner queue snapshot (portable)'
+        $script:labels | Should -Contain 'ops: release control plane local (docker)'
     }
 
     It 'routes tasks through Invoke-PortableOps wrapper' {
@@ -28,5 +29,6 @@ Describe 'VS Code tasks contract for portable workflow ops' {
         $raw | Should -Match 'Cancel-StaleWorkflowRuns\.ps1'
         $raw | Should -Match 'Watch-WorkflowRun\.ps1'
         $raw | Should -Match 'Get-RunnerQueueSnapshot\.ps1'
+        $raw | Should -Match 'Invoke-ReleaseControlPlaneLocalDocker\.ps1'
     }
 }

--- a/tools/ops-runtime/Dockerfile
+++ b/tools/ops-runtime/Dockerfile
@@ -4,4 +4,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git jq gh ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+RUN pwsh -NoLogo -NoProfile -Command "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted; Install-Module -Name Pester -Scope AllUsers -Force -MinimumVersion 5.5.0"
+
 WORKDIR /workspace

--- a/tools/ops-runtime/README.md
+++ b/tools/ops-runtime/README.md
@@ -1,0 +1,23 @@
+# Ops Runtime Container
+
+This container is the portable Docker package for local ops exercises.
+
+Default image:
+- `ghcr.io/svelderrainruiz/labview-cdev-surface-ops:v1`
+
+Build locally:
+
+```powershell
+docker build -f .\tools\ops-runtime\Dockerfile -t labview-cdev-surface-ops:local .\tools\ops-runtime
+```
+
+Run the release control-plane local harness with this package:
+
+```powershell
+pwsh -NoProfile -File .\scripts\Invoke-ReleaseControlPlaneLocalDocker.ps1 `
+  -BuildLocalImage `
+  -LocalTag labview-cdev-surface-ops:local `
+  -Mode Validate `
+  -DryRun `
+  -RunContractTests
+```


### PR DESCRIPTION
## Summary
- add a local Docker harness for autonomous release control-plane exercise:
  - scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1
  - scripts/Exercise-ReleaseControlPlaneLocal.ps1
- add contract coverage and CI inclusion for the new harness
- document usage in README.md, AGENTS.md, and 	ools/ops-runtime/README.md

## Reliability hardening included
- add portable GitHub API helpers in scripts/lib/WorkflowOps.Common.ps1:
  - Get-GhWorkflowRunsPortable
  - Get-GhReleasesPortable
- switch control-plane path scripts from CLI-flag-dependent queries to portable helpers:
  - Invoke-OpsMonitoringSnapshot.ps1
  - Write-OpsSloReport.ps1
  - Invoke-ReleaseControlPlane.ps1
  - Invoke-CanarySmokeTagHygiene.ps1
  - Dispatch-WorkflowAtRemoteHead.ps1
  - Cancel-StaleWorkflowRuns.ps1
  - Watch-WorkflowRun.ps1
- keep deterministic runner-visibility handling (unner_visibility_unavailable) and contract assertions updated

## Container runtime updates
- update 	ools/ops-runtime/Dockerfile to install Pester for in-container contract test execution

## Validation
- local Docker harness (validate + dry run + contract tests):
  - pwsh -NoProfile -File scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1 -Repository LabVIEW-Community-CI-CD/labview-cdev-surface-fork -Branch main -Mode Validate -DryRun -BuildLocalImage -RunContractTests -OutputRoot artifacts/release-control-plane-local
  - result: success, summary and reports generated under rtifacts/release-control-plane-local
- full suite:
  - Invoke-Pester -Path ./tests -CI
  - result: 178/178 passed
