### PR TITLE
feat(ops): publish portable ops runtime image to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
             './tests/CancelStaleWorkflowRunsContract.Tests.ps1',
             './tests/WatchWorkflowRunContract.Tests.ps1',
             './tests/PortableOpsRuntimeContract.Tests.ps1',
+            './tests/OpsRuntimeImagePublishWorkflowContract.Tests.ps1',
             './tests/VsCodeTasksContract.Tests.ps1',
             './tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1',
             './tests/UploadArtifactRetryCompositeContract.Tests.ps1',

--- a/.github/workflows/publish-ops-runtime-image.yml
+++ b/.github/workflows/publish-ops-runtime-image.yml
@@ -1,0 +1,113 @@
+name: publish-ops-runtime-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      promote_v1:
+        description: Also refresh the v1 tag.
+        required: false
+        default: true
+        type: boolean
+      additional_tag:
+        description: Optional extra tag (for example canary or rc1).
+        required: false
+        default: ''
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - tools/ops-runtime/Dockerfile
+      - scripts/Invoke-PortableOps.ps1
+      - scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1
+      - tools/ops-runtime/README.md
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-ops-runtime-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Ops Runtime Image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REPO: ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve deterministic tags
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          date_utc="$(date -u +%Y%m%d)"
+          short_sha="${GITHUB_SHA:0:12}"
+          promote_v1="${{ github.event.inputs.promote_v1 }}"
+          additional_tag="${{ github.event.inputs.additional_tag }}"
+
+          if [[ -z "$promote_v1" ]]; then
+            promote_v1="true"
+          fi
+
+          if [[ -n "$additional_tag" ]] && [[ ! "$additional_tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "additional_tag must match ^[A-Za-z0-9._-]+$" >&2
+            exit 1
+          fi
+
+          tags=()
+          tags+=("${IMAGE_REPO}:sha-${short_sha}")
+          tags+=("${IMAGE_REPO}:v1-${date_utc}")
+          if [[ "$promote_v1" == "true" ]]; then
+            tags+=("${IMAGE_REPO}:v1")
+          fi
+          if [[ -n "$additional_tag" ]]; then
+            tags+=("${IMAGE_REPO}:${additional_tag}")
+          fi
+
+          {
+            echo "date_utc=$date_utc"
+            echo "short_sha=$short_sha"
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./tools/ops-runtime
+          file: ./tools/ops-runtime/Dockerfile
+          push: true
+          tags: ${{ steps.resolve.outputs.tags }}
+
+      - name: Publish summary
+        shell: bash
+        run: |
+          {
+            echo "## Ops Runtime Image Published"
+            echo ""
+            echo "- Image: \`${IMAGE_REPO}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Tags:"
+            while IFS= read -r tag; do
+              echo "  - \`$tag\`"
+            done <<< "${{ steps.resolve.outputs.tags }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -341,9 +341,28 @@ pwsh -NoProfile -File .\scripts\Invoke-ReleaseControlPlaneLocalDocker.ps1 `
 
 This executes `scripts/Exercise-ReleaseControlPlaneLocal.ps1` in the portable ops container image and writes artifacts under:
 - `artifacts\release-control-plane-local`
+- Default container image: `ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops:v1`
 
 For offline or container runtime fallback on the host:
 - add `-HostFallback`
+
+## Publish Ops Runtime Image
+
+`publish-ops-runtime-image.yml` publishes the portable ops runtime container to:
+- `ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops`
+
+Deterministic tags:
+- `sha-<12-char-commit>`
+- `v1-YYYYMMDD`
+- `v1` (when `promote_v1=true`)
+
+Manual publish:
+
+```powershell
+gh workflow run publish-ops-runtime-image.yml `
+  -R LabVIEW-Community-CI-CD/labview-cdev-surface-fork `
+  -f promote_v1=true
+```
 
 Runbook for incidents:
 - `docs/runbooks/release-ops-incident-response.md`

--- a/scripts/Invoke-PortableOps.ps1
+++ b/scripts/Invoke-PortableOps.ps1
@@ -8,7 +8,7 @@ param(
     [string[]]$ScriptArguments = @(),
 
     [Parameter()]
-    [string]$Image = 'ghcr.io/svelderrainruiz/labview-cdev-surface-ops:v1',
+    [string]$Image = 'ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops:v1',
 
     [Parameter()]
     [switch]$BuildLocalImage,

--- a/scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1
+++ b/scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1
@@ -37,7 +37,7 @@ param(
     [string]$OutputRoot = 'artifacts/release-control-plane-local',
 
     [Parameter()]
-    [string]$Image = 'ghcr.io/svelderrainruiz/labview-cdev-surface-ops:v1',
+    [string]$Image = 'ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops:v1',
 
     [Parameter()]
     [switch]$BuildLocalImage,

--- a/tests/OpsRuntimeImagePublishWorkflowContract.Tests.ps1
+++ b/tests/OpsRuntimeImagePublishWorkflowContract.Tests.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Ops runtime image publish workflow contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:workflowPath = Join-Path $script:repoRoot '.github/workflows/publish-ops-runtime-image.yml'
+
+        if (-not (Test-Path -LiteralPath $script:workflowPath -PathType Leaf)) {
+            throw "Ops runtime publish workflow missing: $script:workflowPath"
+        }
+
+        $script:workflowContent = Get-Content -LiteralPath $script:workflowPath -Raw
+    }
+
+    It 'supports manual dispatch and deterministic main-path publish triggers' {
+        $script:workflowContent | Should -Match 'workflow_dispatch:'
+        $script:workflowContent | Should -Match 'push:'
+        $script:workflowContent | Should -Match 'tools/ops-runtime/Dockerfile'
+        $script:workflowContent | Should -Match 'Invoke-PortableOps\.ps1'
+        $script:workflowContent | Should -Match 'Invoke-ReleaseControlPlaneLocalDocker\.ps1'
+    }
+
+    It 'publishes to GHCR with package write permission' {
+        $script:workflowContent | Should -Match 'packages:\s*write'
+        $script:workflowContent | Should -Match 'ghcr\.io/labview-community-ci-cd/labview-cdev-surface-ops'
+        $script:workflowContent | Should -Match 'docker/login-action@v3'
+        $script:workflowContent | Should -Match 'docker/build-push-action@v6'
+    }
+
+    It 'derives immutable tags and reports pushed digest' {
+        $script:workflowContent | Should -Match 'sha-\$\{short_sha\}'
+        $script:workflowContent | Should -Match 'v1-\$\{date_utc\}'
+        $script:workflowContent | Should -Match 'steps\.build\.outputs\.digest'
+    }
+}

--- a/tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1
+++ b/tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Release control plane local Docker harness contract' {
     It 'wraps release control plane local harness through portable container runtime' {
         $script:wrapperContent | Should -Match 'Invoke-PortableOps\.ps1'
         $script:wrapperContent | Should -Match 'Exercise-ReleaseControlPlaneLocal\.ps1'
-        $script:wrapperContent | Should -Match 'ghcr\.io/svelderrainruiz/labview-cdev-surface-ops:v1'
+        $script:wrapperContent | Should -Match 'ghcr\.io/labview-community-ci-cd/labview-cdev-surface-ops:v1'
         $script:wrapperContent | Should -Match 'BuildLocalImage'
         $script:wrapperContent | Should -Match 'HostFallback'
     }

--- a/tools/ops-runtime/README.md
+++ b/tools/ops-runtime/README.md
@@ -3,7 +3,7 @@
 This container is the portable Docker package for local ops exercises.
 
 Default image:
-- `ghcr.io/svelderrainruiz/labview-cdev-surface-ops:v1`
+- `ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops:v1`
 
 Build locally:
 


### PR DESCRIPTION
## Summary
- add publish-ops-runtime-image.yml to publish 	ools/ops-runtime/Dockerfile as a GHCR container image
- publish deterministic tags per run:
  - sha-<12-char-commit>
  - 1-YYYYMMDD
  - optional mutable 1 (controlled by input promote_v1)
- switch portable runtime default image reference to org GHCR namespace:
  - ghcr.io/labview-community-ci-cd/labview-cdev-surface-ops:v1
- add workflow contract test and include it in CI

## Why
Local publish is blocked by current token scopes (permission_denied: token does not match expected scopes). This workflow uses repo-scoped GITHUB_TOKEN with packages: write to publish deterministically from CI.

## Validation
- Invoke-Pester -Path ./tests -CI
- result: 181/181 passed
