### PR TITLE
feat: add container NSIS self-test/parity and Linux parity image publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
             './tests/WatchWorkflowRunContract.Tests.ps1',
             './tests/PortableOpsRuntimeContract.Tests.ps1',
             './tests/OpsRuntimeImagePublishWorkflowContract.Tests.ps1',
+            './tests/LinuxNsisParityImagePublishWorkflowContract.Tests.ps1',
             './tests/VsCodeTasksContract.Tests.ps1',
             './tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1',
             './tests/UploadArtifactRetryCompositeContract.Tests.ps1',
@@ -77,6 +78,8 @@ jobs:
             './tests/LinuxLabviewImageGateWorkflowContract.Tests.ps1',
             './tests/ReleaseWithWindowsGateWorkflowContract.Tests.ps1',
             './tests/DockerDesktopLinuxIterationContract.Tests.ps1',
+            './tests/LinuxContainerNsisParityContract.Tests.ps1',
+            './tests/WindowsContainerNsisSelfTestContract.Tests.ps1',
             './tests/WorkspaceInstallerExerciseContract.Tests.ps1',
             './tests/WorkspaceInstallerIterationContract.Tests.ps1',
             './tests/ScopeAOpsRunbookContract.Tests.ps1'

--- a/.github/workflows/publish-linux-nsis-parity-image.yml
+++ b/.github/workflows/publish-linux-nsis-parity-image.yml
@@ -1,0 +1,114 @@
+name: publish-linux-nsis-parity-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      promote_latest:
+        description: Also refresh the latest tag.
+        required: false
+        default: false
+        type: boolean
+      additional_tag:
+        description: Optional extra tag (for example canary or rc1).
+        required: false
+        default: ''
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - tools/nsis-selftest-linux/Dockerfile
+      - tools/nsis-selftest-linux/README.md
+      - scripts/Invoke-LinuxContainerNsisParity.ps1
+      - .github/workflows/publish-linux-nsis-parity-image.yml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-linux-nsis-parity-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Linux NSIS Parity Image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REPO: ghcr.io/labview-community-ci-cd/labview-cdev-surface-nsis-linux-parity
+      BASE_TAG: 2026q1-linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve deterministic tags
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          date_utc="$(date -u +%Y%m%d)"
+          short_sha="${GITHUB_SHA:0:12}"
+          promote_latest="${{ github.event.inputs.promote_latest }}"
+          additional_tag="${{ github.event.inputs.additional_tag }}"
+
+          if [[ -z "$promote_latest" ]]; then
+            promote_latest="false"
+          fi
+
+          if [[ -n "$additional_tag" ]] && [[ ! "$additional_tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "additional_tag must match ^[A-Za-z0-9._-]+$" >&2
+            exit 1
+          fi
+
+          tags=()
+          tags+=("${IMAGE_REPO}:sha-${short_sha}")
+          tags+=("${IMAGE_REPO}:${BASE_TAG}-${date_utc}")
+          if [[ "$promote_latest" == "true" ]]; then
+            tags+=("${IMAGE_REPO}:latest")
+          fi
+          if [[ -n "$additional_tag" ]]; then
+            tags+=("${IMAGE_REPO}:${additional_tag}")
+          fi
+
+          {
+            echo "date_utc=$date_utc"
+            echo "short_sha=$short_sha"
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./tools/nsis-selftest-linux
+          file: ./tools/nsis-selftest-linux/Dockerfile
+          push: true
+          tags: ${{ steps.resolve.outputs.tags }}
+
+      - name: Publish summary
+        shell: bash
+        run: |
+          {
+            echo "## Linux NSIS Parity Image Published"
+            echo ""
+            echo "- Image: \`${IMAGE_REPO}\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Tags:"
+            while IFS= read -r tag; do
+              echo "  - \`$tag\`"
+            done <<< "${{ steps.resolve.outputs.tags }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,8 @@ Build and gate lanes must run in isolated workspaces on every run (`D:\dev` pref
   - `-Mode full` for isolated smoke install validation.
   - `-Watch` to auto-rerun on contract file changes without manual restarts.
 - Use `scripts/Invoke-DockerDesktopLinuxIteration.ps1 -DockerContext desktop-linux` for Docker Desktop Linux command-surface checks (`runner-cli --help`, `runner-cli ppl --help`) before full Windows LabVIEW image runs.
+- Use `scripts/Invoke-WindowsContainerNsisSelfTest.ps1` to build the workspace NSIS installer and run silent install (`/S`) inside the same Windows container with `ContainerSmoke` execution context; this image is aligned to `nationalinstruments/labview:2026q1-windows` and fails fast with `windows_container_mode_required` if Docker is not in Windows container mode.
+- Use `scripts/Invoke-LinuxContainerNsisParity.ps1 -DockerContext desktop-linux` for parity checks aligned to `nationalinstruments/labview:2026q1-linux`; this lane compiles NSIS smoke output but does not execute Windows installers on Linux.
 - Use `scripts/Invoke-ReleaseControlPlaneLocalDocker.ps1` for local containerized release-control-plane exercise (`Validate` + `DryRun` default).
 - If Docker Desktop Linux context is unavailable, confirm `Microsoft-Hyper-V-All`, `VirtualMachinePlatform`, and `Microsoft-Windows-Subsystem-Linux` are enabled, then reboot before retrying.
 - Use `scripts/Test-RunnerCliBundleDeterminism.ps1` and `scripts/Test-WorkspaceInstallerDeterminism.ps1` locally before proposing release-tag publication.

--- a/nsis/workspace-bootstrap-installer.nsi
+++ b/nsis/workspace-bootstrap-installer.nsi
@@ -39,6 +39,10 @@ Name "LVIE Cdev Workspace Bootstrap"
   !define REQUIRED_LABVIEW_YEAR "2020"
 !endif
 
+!ifndef INSTALL_EXEC_CONTEXT
+  !define INSTALL_EXEC_CONTEXT "NsisInstall"
+!endif
+
 !ifndef X86_NIPKG_ENV
   !define X86_NIPKG_ENV "LVIE_LABVIEW_X86_NIPKG_INSTALL_CMD"
 !endif
@@ -71,6 +75,7 @@ Section "Install"
   FileWrite $2 "manifest=$INSTDIR\${MANIFEST_REL}$\r$\n"
   FileWrite $2 "report=${WORKSPACE_ROOT}\${REPORT_REL}$\r$\n"
   FileWrite $2 "powershell_exe=$1$\r$\n"
+  FileWrite $2 "install_execution_context=${INSTALL_EXEC_CONTEXT}$\r$\n"
   FileWrite $2 "required_labview_year=${REQUIRED_LABVIEW_YEAR}$\r$\n"
   FileClose $2
 
@@ -131,7 +136,7 @@ Section "Install"
   Abort
   labview_x86_ready:
 
-  ExecWait '"$SYSDIR\cmd.exe" /c ""$1" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\${INSTALL_SCRIPT_REL}" -WorkspaceRoot "${WORKSPACE_ROOT}" -ManifestPath "$INSTDIR\${MANIFEST_REL}" -Mode Install -InstallerExecutionContext NsisInstall -OutputPath "${WORKSPACE_ROOT}\${REPORT_REL}" >> "${WORKSPACE_ROOT}\${LAUNCH_LOG_REL}" 2>&1"' $0
+  ExecWait '"$SYSDIR\cmd.exe" /c ""$1" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\${INSTALL_SCRIPT_REL}" -WorkspaceRoot "${WORKSPACE_ROOT}" -ManifestPath "$INSTDIR\${MANIFEST_REL}" -Mode Install -InstallerExecutionContext ${INSTALL_EXEC_CONTEXT} -OutputPath "${WORKSPACE_ROOT}\${REPORT_REL}" >> "${WORKSPACE_ROOT}\${LAUNCH_LOG_REL}" 2>&1"' $0
   FileOpen $2 "${WORKSPACE_ROOT}\${LAUNCH_LOG_REL}" a
   FileWrite $2 "exit_code=$0$\r$\n"
   FileClose $2

--- a/scripts/Build-WorkspaceBootstrapInstaller.ps1
+++ b/scripts/Build-WorkspaceBootstrapInstaller.ps1
@@ -13,6 +13,10 @@ param(
     [string]$RequiredLabviewYear = '2020',
 
     [Parameter(Mandatory = $false)]
+    [ValidateSet('NsisInstall', 'LocalInstallerExercise', 'ContainerSmoke')]
+    [string]$InstallerExecutionContext = 'NsisInstall',
+
+    [Parameter(Mandatory = $false)]
     [string]$NsisScriptPath,
 
     [Parameter(Mandatory = $false)]
@@ -206,6 +210,7 @@ function Invoke-NsisBuild {
         [Parameter(Mandatory = $true)][string]$OutputInstallerPath,
         [Parameter(Mandatory = $true)][string]$WorkspaceRoot,
         [Parameter(Mandatory = $true)][string]$LabviewYear,
+        [Parameter(Mandatory = $true)][string]$InstallExecutionContext,
         [Parameter(Mandatory = $true)][bool]$DeterministicBuild,
         [Parameter(Mandatory = $true)][long]$EpochSeconds
     )
@@ -216,6 +221,7 @@ function Invoke-NsisBuild {
         ("/DPAYLOAD_DIR=$StagedPayloadPath"),
         ("/DWORKSPACE_ROOT=$WorkspaceRoot"),
         ("/DREQUIRED_LABVIEW_YEAR=$LabviewYear"),
+        ("/DINSTALL_EXEC_CONTEXT=$InstallExecutionContext"),
         ("/DSOURCE_DATE_EPOCH=$EpochSeconds"),
         $ScriptPathResolved
     )
@@ -276,6 +282,7 @@ try {
                 -OutputInstallerPath $outputPath `
                 -WorkspaceRoot $WorkspaceRootDefault `
                 -LabviewYear $RequiredLabviewYear `
+                -InstallExecutionContext $InstallerExecutionContext `
                 -DeterministicBuild $Deterministic `
                 -EpochSeconds $epoch
             $hash = Get-Sha256Hex -Path $outputPath
@@ -318,6 +325,7 @@ try {
             -OutputInstallerPath $resolvedOutputPath `
             -WorkspaceRoot $WorkspaceRootDefault `
             -LabviewYear $RequiredLabviewYear `
+            -InstallExecutionContext $InstallerExecutionContext `
             -DeterministicBuild $Deterministic `
             -EpochSeconds $epoch
 

--- a/scripts/Invoke-LinuxContainerNsisParity.ps1
+++ b/scripts/Invoke-LinuxContainerNsisParity.ps1
@@ -1,0 +1,275 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Image = 'labview-cdev-surface-nsis-linux-parity:local',
+
+    [Parameter()]
+    [switch]$BuildLocalImage,
+
+    [Parameter()]
+    [string]$DockerfilePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools\nsis-selftest-linux\Dockerfile'),
+
+    [Parameter()]
+    [string]$DockerContext = 'desktop-linux',
+
+    [Parameter()]
+    [string]$OutputRoot = (Join-Path (Split-Path -Parent $PSScriptRoot) 'artifacts\release\linux-container-nsis-parity'),
+
+    [Parameter()]
+    [string]$ContainerRepoMount = '/repo',
+
+    [Parameter()]
+    [string]$ContainerOutputMount = '/hostout',
+
+    [Parameter()]
+    [ValidatePattern('^[a-z0-9][a-z0-9_.-]{2,50}$')]
+    [string]$ContainerNamePrefix = 'lvie-cdev-linux-nsis',
+
+    [Parameter()]
+    [switch]$KeepContainerScript
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Assert-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+function Get-CommandOutputOrThrow {
+    param(
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Command failed: {0} {1} (exit={2})" -f $Command, ($Arguments -join ' '), $LASTEXITCODE)
+    }
+}
+
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedDockerfilePath = [System.IO.Path]::GetFullPath($DockerfilePath)
+$dockerBuildContext = [System.IO.Path]::GetDirectoryName($resolvedDockerfilePath)
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+$containerScriptPath = Join-Path $resolvedOutputRoot 'container-run.sh'
+$containerReportPath = Join-Path $resolvedOutputRoot 'container-report.json'
+$hostReportPath = Join-Path $resolvedOutputRoot 'linux-container-nsis-parity-report.json'
+
+Assert-Command -Name 'docker'
+
+if (-not (Test-Path -LiteralPath $resolvedDockerfilePath -PathType Leaf)) {
+    throw "Dockerfile not found: $resolvedDockerfilePath"
+}
+
+Ensure-Directory -Path $resolvedOutputRoot
+if (Test-Path -LiteralPath $containerReportPath -PathType Leaf) {
+    Remove-Item -LiteralPath $containerReportPath -Force
+}
+
+$contextArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($DockerContext)) {
+    $contextArgs += @('--context', $DockerContext)
+}
+
+Get-CommandOutputOrThrow -Command 'docker' -Arguments @($contextArgs + @('info'))
+
+if ($BuildLocalImage) {
+    $buildArgs = @($contextArgs + @('build', '-f', $resolvedDockerfilePath, '-t', $Image, $dockerBuildContext))
+    Get-CommandOutputOrThrow -Command 'docker' -Arguments $buildArgs
+}
+
+$containerScriptContent = @'
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="__REPO_MOUNT__"
+host_out="__OUTPUT_MOUNT__"
+work_root="/tmp/nsis-linux-parity"
+smoke_nsi="$work_root/nsis-smoke.nsi"
+smoke_installer="$host_out/nsis-linux-parity-smoke.exe"
+makensis_log="$host_out/makensis-linux-parity.log"
+
+mkdir -p "$host_out"
+rm -rf "$work_root"
+mkdir -p "$work_root"
+
+status="succeeded"
+reason_code=""
+compile_status="not_run"
+smoke_sha256=""
+missing_commands=()
+
+# LabVIEWCLI binary casing varies by image surface; support both deterministic probes.
+if ! command -v "labviewcli" >/dev/null 2>&1 && ! command -v "LabVIEWCLI" >/dev/null 2>&1; then
+  missing_commands+=("LabVIEWCLI")
+fi
+
+for command_name in makensis git dotnet pwsh; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    missing_commands+=("$command_name")
+  fi
+done
+
+if [[ ${#missing_commands[@]} -gt 0 ]]; then
+  status="failed"
+  reason_code="toolchain_missing"
+fi
+
+cat > "$smoke_nsi" <<'NSIS'
+Unicode True
+OutFile "/hostout/nsis-linux-parity-smoke.exe"
+Section
+SectionEnd
+NSIS
+
+if [[ "$status" == "succeeded" ]]; then
+  if makensis -V2 "$smoke_nsi" >"$makensis_log" 2>&1; then
+    compile_status="pass"
+  else
+    compile_status="fail"
+    status="failed"
+    reason_code="nsis_compile_failed"
+  fi
+fi
+
+if [[ -f "$smoke_installer" ]]; then
+  smoke_sha256="$(sha256sum "$smoke_installer" | awk '{print $1}')"
+fi
+
+missing_csv=""
+if [[ ${#missing_commands[@]} -gt 0 ]]; then
+  missing_csv="$(IFS=,; echo "${missing_commands[*]}")"
+fi
+
+jq -n \
+  --arg timestamp "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  --arg status "$status" \
+  --arg reason_code "$reason_code" \
+  --arg missing_csv "$missing_csv" \
+  --arg compile_status "$compile_status" \
+  --arg makensis_log "$makensis_log" \
+  --arg smoke_installer "$smoke_installer" \
+  --arg smoke_sha256 "$smoke_sha256" \
+  --arg installer_execution_status "skipped" \
+  --arg installer_execution_reason "windows_installer_not_executable_on_linux" \
+  '{
+      timestamp_utc: $timestamp,
+      status: $status,
+      reason_code: $reason_code,
+      missing_commands: (if $missing_csv == "" then [] else ($missing_csv | split(",")) end),
+      nsis_compile_status: $compile_status,
+      makensis_log_path: $makensis_log,
+      smoke_installer_path: $smoke_installer,
+      smoke_installer_sha256: $smoke_sha256,
+      installer_execution_status: $installer_execution_status,
+      installer_execution_reason: $installer_execution_reason
+   }' > "$host_out/container-report.json"
+
+if [[ "$status" != "succeeded" ]]; then
+  exit 1
+fi
+
+exit 0
+'@
+
+$containerScriptContent = $containerScriptContent.Replace('__REPO_MOUNT__', $ContainerRepoMount)
+$containerScriptContent = $containerScriptContent.Replace('__OUTPUT_MOUNT__', $ContainerOutputMount)
+$containerScriptContent = $containerScriptContent -replace "`r`n", "`n"
+[System.IO.File]::WriteAllText($containerScriptPath, $containerScriptContent, [System.Text.UTF8Encoding]::new($false))
+
+$containerName = ('{0}-{1}' -f $ContainerNamePrefix, ([guid]::NewGuid().ToString('n').Substring(0, 12))).ToLowerInvariant()
+$dockerRepoVolume = ('{0}:{1}' -f $repoRoot, $ContainerRepoMount)
+$dockerOutputVolume = ('{0}:{1}' -f $resolvedOutputRoot, $ContainerOutputMount)
+$containerScriptInContainer = if ($ContainerOutputMount.EndsWith('/')) {
+    "$ContainerOutputMount" + 'container-run.sh'
+} else {
+    "$ContainerOutputMount/container-run.sh"
+}
+$containerExitCode = 0
+$status = 'unknown'
+$errors = @()
+$containerReport = $null
+$startedUtc = (Get-Date).ToUniversalTime()
+
+try {
+    $runArgs = @($contextArgs + @(
+        'run',
+        '--rm',
+        '--name', $containerName,
+        '-v', $dockerRepoVolume,
+        '-v', $dockerOutputVolume,
+        $Image,
+        'bash', $containerScriptInContainer
+    ))
+
+    & docker @runArgs
+    $containerExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    if ($containerExitCode -ne 0) {
+        throw "docker run failed with exit code $containerExitCode"
+    }
+
+    if (-not (Test-Path -LiteralPath $containerReportPath -PathType Leaf)) {
+        throw "Container report missing: $containerReportPath"
+    }
+
+    $containerReport = Get-Content -LiteralPath $containerReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    if ([string]$containerReport.status -ne 'succeeded') {
+        throw ("Container report status is '{0}' (expected 'succeeded')." -f [string]$containerReport.status)
+    }
+
+    $status = 'succeeded'
+} catch {
+    if ($containerExitCode -eq 0) {
+        $containerExitCode = 1
+    }
+    $status = 'failed'
+    $errors += $_.Exception.Message
+    if (Test-Path -LiteralPath $containerReportPath -PathType Leaf) {
+        try {
+            $containerReport = Get-Content -LiteralPath $containerReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            $errors += "Failed to parse container report JSON: $($_.Exception.Message)"
+        }
+    }
+}
+
+$endedUtc = (Get-Date).ToUniversalTime()
+[ordered]@{
+    timestamp_utc = $endedUtc.ToString('o')
+    started_utc = $startedUtc.ToString('o')
+    status = $status
+    image = $Image
+    build_local_image = [bool]$BuildLocalImage
+    dockerfile = $resolvedDockerfilePath
+    docker_context = $DockerContext
+    container_name = $containerName
+    output_root = $resolvedOutputRoot
+    container_exit_code = $containerExitCode
+    container_report_path = $containerReportPath
+    container_report = $containerReport
+    errors = $errors
+} | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $hostReportPath -Encoding utf8
+
+if (-not $KeepContainerScript -and (Test-Path -LiteralPath $containerScriptPath -PathType Leaf)) {
+    Remove-Item -LiteralPath $containerScriptPath -Force
+}
+
+Write-Host "Linux container NSIS parity report: $hostReportPath"
+
+if ($status -ne 'succeeded') {
+    exit 1
+}
+
+exit 0

--- a/scripts/Invoke-WindowsContainerNsisSelfTest.ps1
+++ b/scripts/Invoke-WindowsContainerNsisSelfTest.ps1
@@ -1,0 +1,410 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$Image = 'labview-cdev-surface-nsis-selftest:local',
+
+    [Parameter()]
+    [switch]$BuildLocalImage,
+
+    [Parameter()]
+    [string]$DockerfilePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'tools\nsis-selftest-windows\Dockerfile'),
+
+    [Parameter()]
+    [string]$DockerContext = '',
+
+    [Parameter()]
+    [string]$OutputRoot = (Join-Path (Split-Path -Parent $PSScriptRoot) 'artifacts\release\windows-container-nsis-selftest'),
+
+    [Parameter()]
+    [string]$HostNsisRoot = 'C:\Program Files (x86)\NSIS',
+
+    [Parameter()]
+    [string]$ContainerWorkspaceRoot = 'C:\dev-smoke-lvie',
+
+    [Parameter()]
+    [string]$ContainerRepoMount = 'C:\repo',
+
+    [Parameter()]
+    [string]$ContainerOutputMount = 'C:\hostout',
+
+    [Parameter()]
+    [string]$ContainerPayloadMount = 'C:\payload',
+
+    [Parameter()]
+    [string]$ContainerNsisMount = 'C:\nsis',
+
+    [Parameter()]
+    [ValidatePattern('^[a-z0-9][a-z0-9_.-]{2,50}$')]
+    [string]$ContainerNamePrefix = 'lvie-cdev-nsis-smoke',
+
+    [Parameter()]
+    [switch]$KeepContainerScript,
+
+    [Parameter()]
+    [switch]$KeepContainerOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Assert-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH."
+    }
+}
+
+function Get-CommandOutputOrThrow {
+    param(
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw ("Command failed: {0} {1} (exit={2})" -f $Command, ($Arguments -join ' '), $LASTEXITCODE)
+    }
+}
+
+function Convert-ToSingleQuotedLiteral {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    return $Value.Replace("'", "''")
+}
+
+$repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+$resolvedDockerfilePath = [System.IO.Path]::GetFullPath($DockerfilePath)
+$dockerBuildContext = [System.IO.Path]::GetDirectoryName($resolvedDockerfilePath)
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+$resolvedHostNsisRoot = [System.IO.Path]::GetFullPath($HostNsisRoot)
+$hostMakensisPath = Join-Path $resolvedHostNsisRoot 'makensis.exe'
+$containerScriptPath = Join-Path $resolvedOutputRoot 'container-run.ps1'
+$containerReportPath = Join-Path $resolvedOutputRoot 'container-report.json'
+$hostReportPath = Join-Path $resolvedOutputRoot 'windows-container-nsis-selftest-report.json'
+$hostPayloadRoot = Join-Path $resolvedOutputRoot 'payload-host'
+$hostPayloadManifestPath = Join-Path $hostPayloadRoot 'workspace-governance\workspace-governance.json'
+$hostRunnerCliOutputRoot = Join-Path $hostPayloadRoot 'tools\runner-cli\win-x64'
+$buildInstallerScript = Join-Path $repoRoot 'scripts\Build-WorkspaceBootstrapInstaller.ps1'
+$buildRunnerCliScript = Join-Path $repoRoot 'scripts\Build-RunnerCliBundleFromManifest.ps1'
+$convertManifestScript = Join-Path $repoRoot 'scripts\Convert-ManifestToWorkspace.ps1'
+$installScript = Join-Path $repoRoot 'scripts\Install-WorkspaceFromManifest.ps1'
+$canonicalPayloadRoot = Join-Path $repoRoot 'workspace-governance-payload'
+
+Assert-Command -Name 'docker'
+Assert-Command -Name 'powershell'
+Assert-Command -Name 'git'
+Assert-Command -Name 'dotnet'
+
+if (-not (Test-Path -LiteralPath $resolvedDockerfilePath -PathType Leaf)) {
+    throw "Dockerfile not found: $resolvedDockerfilePath"
+}
+foreach ($requiredPath in @($buildInstallerScript, $buildRunnerCliScript, $convertManifestScript, $installScript)) {
+    if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+        throw "Required script not found: $requiredPath"
+    }
+}
+if (-not (Test-Path -LiteralPath $canonicalPayloadRoot -PathType Container)) {
+    throw "Canonical payload root not found: $canonicalPayloadRoot"
+}
+if (-not (Test-Path -LiteralPath $hostMakensisPath -PathType Leaf)) {
+    throw ("host_nsis_missing: expected '{0}'. Install NSIS on host or pass -HostNsisRoot." -f $hostMakensisPath)
+}
+
+Ensure-Directory -Path $resolvedOutputRoot
+if (Test-Path -LiteralPath $containerReportPath -PathType Leaf) {
+    Remove-Item -LiteralPath $containerReportPath -Force
+}
+if (Test-Path -LiteralPath $hostPayloadRoot -PathType Container) {
+    Remove-Item -LiteralPath $hostPayloadRoot -Recurse -Force
+}
+Ensure-Directory -Path $hostPayloadRoot
+
+Copy-Item -Path (Join-Path $canonicalPayloadRoot '*') -Destination $hostPayloadRoot -Recurse -Force
+Ensure-Directory -Path (Join-Path $hostPayloadRoot 'scripts')
+Ensure-Directory -Path $hostRunnerCliOutputRoot
+Copy-Item -LiteralPath $installScript -Destination (Join-Path $hostPayloadRoot 'scripts\Install-WorkspaceFromManifest.ps1') -Force
+
+& $buildRunnerCliScript `
+    -ManifestPath $hostPayloadManifestPath `
+    -OutputRoot $hostRunnerCliOutputRoot `
+    -RepoName 'labview-icon-editor' `
+    -Runtime 'win-x64' `
+    -Deterministic:$true | Out-Host
+if ($LASTEXITCODE -ne 0) {
+    throw "Build-RunnerCliBundleFromManifest.ps1 failed with exit code $LASTEXITCODE"
+}
+
+& $convertManifestScript -ManifestPath $hostPayloadManifestPath -WorkspaceRoot $ContainerWorkspaceRoot | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Convert-ManifestToWorkspace.ps1 failed with exit code $LASTEXITCODE"
+}
+
+$contextArgs = @()
+if (-not [string]::IsNullOrWhiteSpace($DockerContext)) {
+    $contextArgs += @('--context', $DockerContext)
+}
+
+$dockerOsTypeRaw = & docker @($contextArgs + @('info', '--format', '{{.OSType}}')) 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw ("docker_info_failed: unable to query Docker engine OSType for context '{0}'." -f $DockerContext)
+}
+$dockerOsType = ([string]$dockerOsTypeRaw).Trim().ToLowerInvariant()
+if ($dockerOsType -ne 'windows') {
+    throw ("windows_container_mode_required: Docker engine OSType is '{0}' for context '{1}'. Switch Docker Desktop to Windows containers or use a Windows-engine context." -f $dockerOsType, $DockerContext)
+}
+
+if ($BuildLocalImage) {
+    $buildArgs = @($contextArgs + @('build', '-f', $resolvedDockerfilePath, '-t', $Image, $dockerBuildContext))
+    Get-CommandOutputOrThrow -Command 'docker' -Arguments $buildArgs
+}
+
+$containerScriptTemplate = @'
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        New-Item -Path $Path -ItemType Directory -Force | Out-Null
+    }
+}
+
+function Assert-Command {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH in container."
+    }
+}
+
+$repoRoot = '__REPO_MOUNT__'
+$payloadRoot = '__PAYLOAD_MOUNT__'
+$nsisRoot = '__NSIS_MOUNT__'
+$hostOut = '__OUTPUT_MOUNT__'
+$workspaceRoot = '__WORKSPACE_ROOT__'
+$workRoot = 'C:\workspace\nsis-selftest'
+$installerPath = Join-Path $workRoot 'lvie-cdev-workspace-installer-container-smoke.exe'
+$installReportPath = Join-Path $workspaceRoot 'artifacts\workspace-install-latest.json'
+$launchLogPath = Join-Path $workspaceRoot 'artifacts\workspace-installer-launch.log'
+$buildInstallerScript = Join-Path $repoRoot 'scripts\Build-WorkspaceBootstrapInstaller.ps1'
+$containerMakensisPath = Join-Path $nsisRoot 'makensis.exe'
+
+$containerStatus = 'unknown'
+$errorMessage = ''
+$reasonCode = ''
+$installerSha256 = ''
+$installerExitCode = 0
+$installReportStatus = ''
+$installReportErrors = @()
+$installReportWarnings = @()
+
+try {
+    Assert-Command -Name 'powershell'
+    if (-not (Test-Path -LiteralPath $buildInstallerScript -PathType Leaf)) {
+        throw "Required build script missing in mounted repo: $buildInstallerScript"
+    }
+    if (-not (Test-Path -LiteralPath $payloadRoot -PathType Container)) {
+        throw "Mounted payload root not found: $payloadRoot"
+    }
+    if (-not (Test-Path -LiteralPath $containerMakensisPath -PathType Leaf)) {
+        throw "Mounted NSIS binary not found: $containerMakensisPath"
+    }
+
+    if (Test-Path -LiteralPath $workRoot -PathType Container) {
+        Remove-Item -LiteralPath $workRoot -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $workspaceRoot -PathType Container) {
+        Remove-Item -LiteralPath $workspaceRoot -Recurse -Force
+    }
+    Ensure-Directory -Path $workRoot
+    Ensure-Directory -Path $workspaceRoot
+
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $buildInstallerScript `
+        -PayloadRoot $payloadRoot `
+        -OutputPath $installerPath `
+        -WorkspaceRootDefault $workspaceRoot `
+        -InstallerExecutionContext 'ContainerSmoke' `
+        -NsisRoot $nsisRoot `
+        -Deterministic:$true | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Build-WorkspaceBootstrapInstaller.ps1 failed in container with exit code $LASTEXITCODE"
+    }
+    if (-not (Test-Path -LiteralPath $installerPath -PathType Leaf)) {
+        throw "Installer output not found: $installerPath"
+    }
+
+    $installerSha256 = (Get-FileHash -LiteralPath $installerPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    "{0} *{1}" -f $installerSha256, (Split-Path -Path $installerPath -Leaf) | Set-Content -LiteralPath "$installerPath.sha256" -Encoding ascii
+
+    & $installerPath '/S' | Out-Host
+    $installerExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    if ($installerExitCode -ne 0) {
+        $reasonCode = 'installer_exit_nonzero'
+        throw "Installer failed in container with exit code $installerExitCode"
+    }
+
+    if (-not (Test-Path -LiteralPath $installReportPath -PathType Leaf)) {
+        $reasonCode = 'install_report_missing'
+        throw "Install report not found after container smoke install: $installReportPath"
+    }
+
+    $installReport = Get-Content -LiteralPath $installReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    $installReportStatus = [string]$installReport.status
+    $installReportErrors = @($installReport.errors)
+    $installReportWarnings = @($installReport.warnings)
+    if ($installReportStatus -ne 'succeeded') {
+        $reasonCode = 'install_report_failed'
+        throw "Install report status is '$installReportStatus' (expected 'succeeded')."
+    }
+
+    Copy-Item -LiteralPath $installerPath -Destination (Join-Path $hostOut 'lvie-cdev-workspace-installer-container-smoke.exe') -Force
+    Copy-Item -LiteralPath "$installerPath.sha256" -Destination (Join-Path $hostOut 'lvie-cdev-workspace-installer-container-smoke.exe.sha256') -Force
+    Copy-Item -LiteralPath $installReportPath -Destination (Join-Path $hostOut 'workspace-install-latest.container-smoke.json') -Force
+    if (Test-Path -LiteralPath $launchLogPath -PathType Leaf) {
+        Copy-Item -LiteralPath $launchLogPath -Destination (Join-Path $hostOut 'workspace-installer-launch.container-smoke.log') -Force
+    }
+
+    $containerStatus = 'succeeded'
+} catch {
+    if ([string]::IsNullOrWhiteSpace($reasonCode)) {
+        $reasonCode = 'container_smoke_failed'
+    }
+    $containerStatus = 'failed'
+    $errorMessage = $_.Exception.Message
+}
+
+[ordered]@{
+    timestamp_utc = (Get-Date).ToUniversalTime().ToString('o')
+    status = $containerStatus
+    reason_code = $reasonCode
+    repo_root = $repoRoot
+    payload_root = $payloadRoot
+    nsis_root = $nsisRoot
+    host_output = $hostOut
+    workspace_root = $workspaceRoot
+    work_root = $workRoot
+    installer_path = $installerPath
+    installer_sha256 = $installerSha256
+    installer_exit_code = $installerExitCode
+    install_report_path = $installReportPath
+    install_report_status = $installReportStatus
+    install_report_errors = @($installReportErrors)
+    install_report_warnings = @($installReportWarnings)
+    launch_log_path = $launchLogPath
+    error_message = $errorMessage
+} | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath (Join-Path $hostOut 'container-report.json') -Encoding utf8
+
+if ($containerStatus -ne 'succeeded') {
+    exit 1
+}
+exit 0
+'@
+
+$containerScriptContent = $containerScriptTemplate
+$containerScriptContent = $containerScriptContent.Replace('__REPO_MOUNT__', (Convert-ToSingleQuotedLiteral -Value $ContainerRepoMount))
+$containerScriptContent = $containerScriptContent.Replace('__PAYLOAD_MOUNT__', (Convert-ToSingleQuotedLiteral -Value $ContainerPayloadMount))
+$containerScriptContent = $containerScriptContent.Replace('__NSIS_MOUNT__', (Convert-ToSingleQuotedLiteral -Value $ContainerNsisMount))
+$containerScriptContent = $containerScriptContent.Replace('__OUTPUT_MOUNT__', (Convert-ToSingleQuotedLiteral -Value $ContainerOutputMount))
+$containerScriptContent = $containerScriptContent.Replace('__WORKSPACE_ROOT__', (Convert-ToSingleQuotedLiteral -Value $ContainerWorkspaceRoot))
+Set-Content -LiteralPath $containerScriptPath -Value $containerScriptContent -Encoding utf8
+
+$containerName = ('{0}-{1}' -f $ContainerNamePrefix, ([guid]::NewGuid().ToString('n').Substring(0, 12))).ToLowerInvariant()
+$dockerRepoVolume = ('{0}:{1}' -f $repoRoot, $ContainerRepoMount)
+$dockerOutputVolume = ('{0}:{1}' -f $resolvedOutputRoot, $ContainerOutputMount)
+$dockerPayloadVolume = ('{0}:{1}' -f $hostPayloadRoot, $ContainerPayloadMount)
+$dockerNsisVolume = ('{0}:{1}' -f $resolvedHostNsisRoot, $ContainerNsisMount)
+$containerExitCode = 0
+$status = 'unknown'
+$errors = @()
+$containerReport = $null
+$startedUtc = (Get-Date).ToUniversalTime()
+$removeOnExit = -not $KeepContainerOnFailure
+
+try {
+    $runArgs = @($contextArgs + @('run'))
+    if ($removeOnExit) {
+        $runArgs += '--rm'
+    }
+    $runArgs += @(
+        '--name', $containerName,
+        '-v', $dockerRepoVolume,
+        '-v', $dockerOutputVolume,
+        '-v', $dockerPayloadVolume,
+        '-v', $dockerNsisVolume,
+        $Image,
+        'powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (Join-Path $ContainerOutputMount 'container-run.ps1')
+    )
+
+    & docker @runArgs
+    $containerExitCode = if ($null -eq $LASTEXITCODE) { 0 } else { [int]$LASTEXITCODE }
+    if ($containerExitCode -ne 0) {
+        throw "docker run failed with exit code $containerExitCode"
+    }
+    if (-not (Test-Path -LiteralPath $containerReportPath -PathType Leaf)) {
+        throw "Container report missing: $containerReportPath"
+    }
+
+    $containerReport = Get-Content -LiteralPath $containerReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+    if ([string]$containerReport.status -ne 'succeeded') {
+        throw ("Container report status is '{0}' (expected 'succeeded')." -f [string]$containerReport.status)
+    }
+
+    $status = 'succeeded'
+} catch {
+    if ($containerExitCode -eq 0) {
+        $containerExitCode = 1
+    }
+    $status = 'failed'
+    $errors += $_.Exception.Message
+    if (Test-Path -LiteralPath $containerReportPath -PathType Leaf) {
+        try {
+            $containerReport = Get-Content -LiteralPath $containerReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            $errors += "Failed to parse container report JSON: $($_.Exception.Message)"
+        }
+    }
+} finally {
+    if ($KeepContainerOnFailure -and $status -eq 'succeeded') {
+        & docker @($contextArgs + @('rm', '-f', $containerName)) *> $null
+    }
+}
+
+$endedUtc = (Get-Date).ToUniversalTime()
+[ordered]@{
+    timestamp_utc = $endedUtc.ToString('o')
+    started_utc = $startedUtc.ToString('o')
+    status = $status
+    image = $Image
+    build_local_image = [bool]$BuildLocalImage
+    dockerfile = $resolvedDockerfilePath
+    docker_context = $DockerContext
+    container_name = $containerName
+    output_root = $resolvedOutputRoot
+    host_payload_root = $hostPayloadRoot
+    host_nsis_root = $resolvedHostNsisRoot
+    container_workspace_root = $ContainerWorkspaceRoot
+    container_exit_code = $containerExitCode
+    container_report_path = $containerReportPath
+    container_report = $containerReport
+    errors = $errors
+} | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $hostReportPath -Encoding utf8
+
+if (-not $KeepContainerScript -and (Test-Path -LiteralPath $containerScriptPath -PathType Leaf)) {
+    Remove-Item -LiteralPath $containerScriptPath -Force
+}
+
+Write-Host "Windows container NSIS self-test report: $hostReportPath"
+
+if ($status -ne 'succeeded') {
+    exit 1
+}
+exit 0

--- a/tests/Build-WorkspaceBootstrapInstaller.Tests.ps1
+++ b/tests/Build-WorkspaceBootstrapInstaller.Tests.ps1
@@ -41,6 +41,8 @@ Describe 'Build-WorkspaceBootstrapInstaller script' {
 
     It 'supports deterministic compare mode parameters' {
         $scriptContent = Get-Content -Path $script:scriptPath -Raw
+        $scriptContent | Should -Match '\[ValidateSet\(''NsisInstall'', ''LocalInstallerExercise'', ''ContainerSmoke''\)\]'
+        $scriptContent | Should -Match '/DINSTALL_EXEC_CONTEXT='
         $scriptContent | Should -Match '\[bool\]\$Deterministic = \$true'
         $scriptContent | Should -Match '\[long\]\$SourceDateEpoch'
         $scriptContent | Should -Match '\[switch\]\$VerifyDeterminism'

--- a/tests/LinuxContainerNsisParityContract.Tests.ps1
+++ b/tests/LinuxContainerNsisParityContract.Tests.ps1
@@ -1,0 +1,53 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Linux container NSIS parity contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:parityScriptPath = Join-Path $script:repoRoot 'scripts/Invoke-LinuxContainerNsisParity.ps1'
+        $script:dockerfilePath = Join-Path $script:repoRoot 'tools/nsis-selftest-linux/Dockerfile'
+
+        if (-not (Test-Path -LiteralPath $script:parityScriptPath -PathType Leaf)) {
+            throw "Linux NSIS parity script missing: $script:parityScriptPath"
+        }
+        if (-not (Test-Path -LiteralPath $script:dockerfilePath -PathType Leaf)) {
+            throw "Linux NSIS parity Dockerfile missing: $script:dockerfilePath"
+        }
+
+        $script:parityScriptContent = Get-Content -LiteralPath $script:parityScriptPath -Raw
+        $script:dockerfileContent = Get-Content -LiteralPath $script:dockerfilePath -Raw
+    }
+
+    It 'runs a Linux parity container flow against desktop-linux context' {
+        $script:parityScriptContent | Should -Match '\[string\]\$DockerContext\s*=\s*''desktop-linux'''
+        $script:parityScriptContent | Should -Match 'docker run'
+        $script:parityScriptContent | Should -Match 'container-report\.json'
+        $script:parityScriptContent | Should -Match 'linux-container-nsis-parity-report\.json'
+        $script:parityScriptContent | Should -Match 'labviewcli'
+        $script:parityScriptContent | Should -Match 'LabVIEWCLI'
+        $script:parityScriptContent | Should -Match 'makensis'
+        $script:parityScriptContent | Should -Match 'windows_installer_not_executable_on_linux'
+    }
+
+    It 'defines deterministic linux parity image dependencies' {
+        $script:dockerfileContent | Should -Match 'FROM nationalinstruments/labview:2026q1-linux'
+        $script:dockerfileContent | Should -Match 'apt-get install -y --no-install-recommends'
+        $script:dockerfileContent | Should -Match 'packages\.microsoft\.com/ubuntu/22\.04/prod'
+        $script:dockerfileContent | Should -Match 'dotnet-sdk-8\.0'
+        $script:dockerfileContent | Should -Match 'powershell'
+        $script:dockerfileContent | Should -Match 'nsis'
+        $script:dockerfileContent | Should -Match 'git'
+        $script:dockerfileContent | Should -Match 'jq'
+        $script:dockerfileContent | Should -Match 'gtk-update-icon-cache'
+        $script:dockerfileContent | Should -Match 'desktop-file-utils'
+    }
+
+    It 'has parse-safe PowerShell syntax' {
+        $tokens = $null
+        $errors = $null
+        [void][System.Management.Automation.Language.Parser]::ParseInput($script:parityScriptContent, [ref]$tokens, [ref]$errors)
+        @($errors).Count | Should -Be 0
+    }
+}

--- a/tests/LinuxNsisParityImagePublishWorkflowContract.Tests.ps1
+++ b/tests/LinuxNsisParityImagePublishWorkflowContract.Tests.ps1
@@ -1,0 +1,38 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Linux NSIS parity image publish workflow contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:workflowPath = Join-Path $script:repoRoot '.github/workflows/publish-linux-nsis-parity-image.yml'
+
+        if (-not (Test-Path -LiteralPath $script:workflowPath -PathType Leaf)) {
+            throw "Linux NSIS parity image publish workflow missing: $script:workflowPath"
+        }
+
+        $script:workflowContent = Get-Content -LiteralPath $script:workflowPath -Raw
+    }
+
+    It 'supports manual dispatch and deterministic main-path publish triggers' {
+        $script:workflowContent | Should -Match 'workflow_dispatch:'
+        $script:workflowContent | Should -Match 'push:'
+        $script:workflowContent | Should -Match 'tools/nsis-selftest-linux/Dockerfile'
+        $script:workflowContent | Should -Match 'scripts/Invoke-LinuxContainerNsisParity\.ps1'
+    }
+
+    It 'publishes to GHCR with package write permission' {
+        $script:workflowContent | Should -Match 'packages:\s*write'
+        $script:workflowContent | Should -Match 'ghcr\.io/labview-community-ci-cd/labview-cdev-surface-nsis-linux-parity'
+        $script:workflowContent | Should -Match 'docker/login-action@v3'
+        $script:workflowContent | Should -Match 'docker/build-push-action@v6'
+    }
+
+    It 'derives immutable tags and reports pushed digest' {
+        $script:workflowContent | Should -Match 'sha-\$\{short_sha\}'
+        $script:workflowContent | Should -Match 'BASE_TAG:\s*2026q1-linux'
+        $script:workflowContent | Should -Match '\$\{BASE_TAG\}-\$\{date_utc\}'
+        $script:workflowContent | Should -Match 'steps\.build\.outputs\.digest'
+    }
+}

--- a/tests/WindowsContainerNsisSelfTestContract.Tests.ps1
+++ b/tests/WindowsContainerNsisSelfTestContract.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Windows container NSIS self-test contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:selfTestScriptPath = Join-Path $script:repoRoot 'scripts/Invoke-WindowsContainerNsisSelfTest.ps1'
+        $script:dockerfilePath = Join-Path $script:repoRoot 'tools/nsis-selftest-windows/Dockerfile'
+
+        if (-not (Test-Path -LiteralPath $script:selfTestScriptPath -PathType Leaf)) {
+            throw "Windows container self-test script missing: $script:selfTestScriptPath"
+        }
+        if (-not (Test-Path -LiteralPath $script:dockerfilePath -PathType Leaf)) {
+            throw "Windows self-test Dockerfile missing: $script:dockerfilePath"
+        }
+
+        $script:selfTestScriptContent = Get-Content -LiteralPath $script:selfTestScriptPath -Raw
+        $script:dockerfileContent = Get-Content -LiteralPath $script:dockerfilePath -Raw
+    }
+
+    It 'builds and runs a Windows containerized NSIS smoke install flow' {
+        $script:selfTestScriptContent | Should -Match '''build'', ''-f'''
+        $script:selfTestScriptContent | Should -Match '''run'''
+        $script:selfTestScriptContent | Should -Match '& docker @runArgs'
+        $script:selfTestScriptContent | Should -Match '''--format'', ''\{\{\.OSType\}\}'''
+        $script:selfTestScriptContent | Should -Match 'windows_container_mode_required'
+        $script:selfTestScriptContent | Should -Match 'Build-RunnerCliBundleFromManifest\.ps1'
+        $script:selfTestScriptContent | Should -Match 'Build-WorkspaceBootstrapInstaller\.ps1'
+        $script:selfTestScriptContent | Should -Match 'Convert-ManifestToWorkspace\.ps1'
+        $script:selfTestScriptContent | Should -Match '-InstallerExecutionContext ''ContainerSmoke'''
+        $script:selfTestScriptContent | Should -Match '''/S'''
+        $script:selfTestScriptContent | Should -Match 'workspace-install-latest\.json'
+        $script:selfTestScriptContent | Should -Match 'container-report\.json'
+        $script:selfTestScriptContent | Should -Match 'windows-container-nsis-selftest-report\.json'
+    }
+
+    It 'supports deterministic troubleshooting controls for container lifecycle' {
+        $script:selfTestScriptContent | Should -Match '\[switch\]\$BuildLocalImage'
+        $script:selfTestScriptContent | Should -Match '\[switch\]\$KeepContainerScript'
+        $script:selfTestScriptContent | Should -Match '\[switch\]\$KeepContainerOnFailure'
+        $script:selfTestScriptContent | Should -Match '\$ContainerNamePrefix'
+        $script:selfTestScriptContent | Should -Match '\$DockerContext'
+    }
+
+    It 'pins a Windows base image aligned to 2026q1 with minimal runtime surface' {
+        $script:dockerfileContent | Should -Match 'nationalinstruments/labview:2026q1-windows'
+        $script:dockerfileContent | Should -Match 'SHELL \["powershell"'
+        $script:dockerfileContent | Should -Match 'WORKDIR C:\\workspace'
+        $script:dockerfileContent | Should -Not -Match 'dotnet-install\.ps1'
+        $script:dockerfileContent | Should -Not -Match 'MinGit-'
+        $script:dockerfileContent | Should -Not -Match 'nsis-'
+    }
+
+    It 'has parse-safe PowerShell syntax' {
+        $tokens = $null
+        $errors = $null
+        [void][System.Management.Automation.Language.Parser]::ParseInput($script:selfTestScriptContent, [ref]$tokens, [ref]$errors)
+        @($errors).Count | Should -Be 0
+    }
+}

--- a/tests/WorkspaceInstallRuntimeContract.Tests.ps1
+++ b/tests/WorkspaceInstallRuntimeContract.Tests.ps1
@@ -26,6 +26,8 @@ Describe 'Workspace install runtime contract' {
         $script:scriptContent | Should -Match "Get-Command 'pwsh'"
         $script:scriptContent | Should -Match "Required command 'powershell' \(or fallback 'pwsh'\)"
         $script:scriptContent | Should -Match 'foreach \(\$commandName in @\(''git'', ''gh'', ''g-cli''\)\)'
+        $script:scriptContent | Should -Match 'Optional command ''\$commandName'' was not found on PATH for ContainerSmoke context.'
+        $script:scriptContent | Should -Match 'ContainerSmoke context forces LVIE_OFFLINE_GIT_MODE behavior.'
         $script:scriptContent | Should -Match 'invalid pinned_sha'
         $script:scriptContent | Should -Match 'head_sha_mismatch'
         $script:scriptContent | Should -Match 'remote_mismatch_'
@@ -50,9 +52,12 @@ Describe 'Workspace install runtime contract' {
         $script:scriptContent | Should -Match 'LVIE_INSTALLER_EXECUTION_PROFILE'
         $script:scriptContent | Should -Match 'host-release'
         $script:scriptContent | Should -Match 'container-parity'
+        $script:scriptContent | Should -Match 'ContainerSmoke context skips repository contract enforcement.'
         $script:scriptContent | Should -Match 'required_ppl_bitnesses'
         $script:scriptContent | Should -Match 'required_vip_bitness'
         $script:scriptContent | Should -Match '-InstallerExecutionContext NsisInstall'
+        $script:scriptContent | Should -Match 'ContainerSmoke context skips runner-cli PPL capability gates.'
+        $script:scriptContent | Should -Match 'ContainerSmoke context skips runner-cli VIP harness gate.'
         $script:scriptContent | Should -Match 'Container parity profile requires LVIE_GATE_SINGLE_PPL_BITNESS'
         $script:scriptContent | Should -Match 'Invoke-RunnerCliPplCapabilityCheck'
         $script:scriptContent | Should -Match 'Test-PplBuildLabVIEWVersionAlignment'

--- a/tests/WorkspaceSurfaceContract.Tests.ps1
+++ b/tests/WorkspaceSurfaceContract.Tests.ps1
@@ -31,6 +31,10 @@ Describe 'Workspace surface contract' {
         $script:installFromReleaseScriptPath = Join-Path $script:repoRoot 'scripts/Install-WorkspaceInstallerFromRelease.ps1'
         $script:testReleaseClientContractsScriptPath = Join-Path $script:repoRoot 'scripts/Test-ReleaseClientContracts.ps1'
         $script:dockerLinuxIterationScriptPath = Join-Path $script:repoRoot 'scripts/Invoke-DockerDesktopLinuxIteration.ps1'
+        $script:windowsContainerNsisSelfTestScriptPath = Join-Path $script:repoRoot 'scripts/Invoke-WindowsContainerNsisSelfTest.ps1'
+        $script:windowsContainerNsisDockerfilePath = Join-Path $script:repoRoot 'tools/nsis-selftest-windows/Dockerfile'
+        $script:linuxContainerNsisParityScriptPath = Join-Path $script:repoRoot 'scripts/Invoke-LinuxContainerNsisParity.ps1'
+        $script:linuxContainerNsisDockerfilePath = Join-Path $script:repoRoot 'tools/nsis-selftest-linux/Dockerfile'
         $script:nsisInstallerPath = Join-Path $script:repoRoot 'nsis/workspace-bootstrap-installer.nsi'
         $script:ciWorkflowPath = Join-Path $script:repoRoot '.github/workflows/ci.yml'
         $script:driftWorkflowPath = Join-Path $script:repoRoot '.github/workflows/workspace-sha-drift-signal.yml'
@@ -41,6 +45,7 @@ Describe 'Workspace surface contract' {
         $script:releaseCoreWorkflowPath = Join-Path $script:repoRoot '.github/workflows/_release-workspace-installer-core.yml'
         $script:releaseWithGateWorkflowPath = Join-Path $script:repoRoot '.github/workflows/release-with-windows-gate.yml'
         $script:canaryWorkflowPath = Join-Path $script:repoRoot '.github/workflows/nightly-supplychain-canary.yml'
+        $script:linuxNsisParityImagePublishWorkflowPath = Join-Path $script:repoRoot '.github/workflows/publish-linux-nsis-parity-image.yml'
         $script:windowsImageGateWorkflowPath = Join-Path $script:repoRoot '.github/workflows/windows-labview-image-gate.yml'
         $script:windowsImageGateCoreWorkflowPath = Join-Path $script:repoRoot '.github/workflows/_windows-labview-image-gate-core.yml'
         $script:linuxImageGateWorkflowPath = Join-Path $script:repoRoot '.github/workflows/linux-labview-image-gate.yml'
@@ -83,6 +88,10 @@ Describe 'Workspace surface contract' {
             $script:installFromReleaseScriptPath,
             $script:testReleaseClientContractsScriptPath,
             $script:dockerLinuxIterationScriptPath,
+            $script:windowsContainerNsisSelfTestScriptPath,
+            $script:windowsContainerNsisDockerfilePath,
+            $script:linuxContainerNsisParityScriptPath,
+            $script:linuxContainerNsisDockerfilePath,
             $script:nsisInstallerPath,
             $script:ciWorkflowPath,
             $script:driftWorkflowPath,
@@ -93,6 +102,7 @@ Describe 'Workspace surface contract' {
             $script:releaseCoreWorkflowPath,
             $script:releaseWithGateWorkflowPath,
             $script:canaryWorkflowPath,
+            $script:linuxNsisParityImagePublishWorkflowPath,
             $script:windowsImageGateWorkflowPath,
             $script:windowsImageGateCoreWorkflowPath,
             $script:linuxImageGateWorkflowPath,
@@ -368,6 +378,9 @@ Describe 'Workspace surface contract' {
         $script:ciWorkflowContent | Should -Match 'WorkspaceShaRefreshPrContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'WorkspaceManifestPinRefreshScript\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'LinuxLabviewImageGateWorkflowContract\.Tests\.ps1'
+        $script:ciWorkflowContent | Should -Match 'LinuxContainerNsisParityContract\.Tests\.ps1'
+        $script:ciWorkflowContent | Should -Match 'LinuxNsisParityImagePublishWorkflowContract\.Tests\.ps1'
+        $script:ciWorkflowContent | Should -Match 'WindowsContainerNsisSelfTestContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'IsolatedBuildWorkspacePolicyContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'GitSafeDirectoryPolicyContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'ENABLE_SELF_HOSTED_CONTRACTS'

--- a/tools/nsis-selftest-linux/Dockerfile
+++ b/tools/nsis-selftest-linux/Dockerfile
@@ -1,0 +1,35 @@
+FROM nationalinstruments/labview:2026q1-linux
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        desktop-file-utils \
+        gpg \
+        gtk-update-icon-cache \
+        libglu1-mesa \
+        libx11-6 \
+        libxinerama1 \
+        xvfb \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg \
+    && chmod go+r /etc/apt/keyrings/microsoft.gpg \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" > /etc/apt/sources.list.d/microsoft-prod.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        dotnet-sdk-8.0 \
+        git \
+        jq \
+        nsis \
+        powershell \
+        unzip \
+        xz-utils \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/tools/nsis-selftest-linux/README.md
+++ b/tools/nsis-selftest-linux/README.md
@@ -1,0 +1,28 @@
+# Linux NSIS Parity Runtime
+
+This image mirrors the containerized NSIS self-test posture on Linux, aligned to `nationalinstruments/labview:2026q1-linux`.
+
+## Purpose
+
+- Provide a Linux parity runtime that includes LabVIEW base image context plus NSIS, git, dotnet, and PowerShell.
+- Exercise deterministic toolchain probes and NSIS smoke compile from the same runtime used for Linux parity lanes.
+- Emit machine-readable parity reports via `scripts/Invoke-LinuxContainerNsisParity.ps1`.
+- Keep dependency installation apt-driven for Ubuntu 22.04 parity, consistent with NI container guidance in `docs/linux-custom-images.md`.
+
+## Included tooling
+
+- Base image: `nationalinstruments/labview:2026q1-linux`
+- Microsoft apt feed (`packages.microsoft.com/ubuntu/22.04/prod`)
+- `.NET SDK` via `dotnet-sdk-8.0` (apt)
+- `PowerShell` via `powershell` (apt)
+- `git`, `jq`, `nsis`
+- LabVIEW-supporting Linux dependencies kept explicit: `desktop-file-utils`, `gtk-update-icon-cache`, `libglu1-mesa`, `libx11-6`, `libxinerama1`, `xvfb`
+
+## Build manually
+
+```powershell
+docker build `
+  -f .\tools\nsis-selftest-linux\Dockerfile `
+  -t labview-cdev-surface-nsis-linux-parity:local `
+  .\tools\nsis-selftest-linux
+```

--- a/tools/nsis-selftest-windows/Dockerfile
+++ b/tools/nsis-selftest-windows/Dockerfile
@@ -1,0 +1,6 @@
+# escape=`
+FROM nationalinstruments/labview:2026q1-windows
+
+SHELL ["powershell", "-NoLogo", "-NoProfile", "-Command", "$ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue';"]
+
+WORKDIR C:\workspace

--- a/tools/nsis-selftest-windows/README.md
+++ b/tools/nsis-selftest-windows/README.md
@@ -1,0 +1,30 @@
+# Windows NSIS Self-Test Runtime
+
+This image is the local runtime for `scripts/Invoke-WindowsContainerNsisSelfTest.ps1`.
+
+## Purpose
+
+- Build the workspace NSIS installer inside a Windows container.
+- Run the installer in the same container for smoke validation.
+- Validate install report output before the container exits.
+
+## Included tooling
+
+- Base image: `nationalinstruments/labview:2026q1-windows`
+- Windows PowerShell (from base image)
+- Host-mounted NSIS toolchain (`makensis.exe`)
+- Host-prestaged payload containing bundled `runner-cli`
+
+## Host prerequisites
+
+- `C:\Program Files (x86)\NSIS\makensis.exe` available on host (override via wrapper parameters).
+- Host `git` and `dotnet` available for payload staging (`Build-RunnerCliBundleFromManifest.ps1` runs on host before container launch).
+
+## Build manually
+
+```powershell
+docker build `
+  -f .\tools\nsis-selftest-windows\Dockerfile `
+  -t labview-cdev-surface-nsis-selftest:local `
+  .\tools\nsis-selftest-windows
+```


### PR DESCRIPTION
## Summary\n- add Windows container NSIS self-test runtime + wrapper + contracts\n- add Linux NSIS parity runtime aligned to 2026q1-linux with apt-driven dependencies\n- add GHCR publish workflow for linux parity image with deterministic tags\n- extend docs and CI contract coverage for the new runtime/publish surfaces\n\n## Validation\n- Invoke-Pester -Path ./tests -CI (191 passed)\n- Invoke-LinuxContainerNsisParity.ps1 -BuildLocalImage -DockerContext desktop-linux (succeeded)\n