### PR TITLE
feat: publish Windows NSIS parity image with silent self-test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             './tests/PortableOpsRuntimeContract.Tests.ps1',
             './tests/OpsRuntimeImagePublishWorkflowContract.Tests.ps1',
             './tests/LinuxNsisParityImagePublishWorkflowContract.Tests.ps1',
+            './tests/WindowsNsisParityImagePublishWorkflowContract.Tests.ps1',
             './tests/VsCodeTasksContract.Tests.ps1',
             './tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1',
             './tests/UploadArtifactRetryCompositeContract.Tests.ps1',

--- a/.github/workflows/publish-windows-nsis-parity-image.yml
+++ b/.github/workflows/publish-windows-nsis-parity-image.yml
@@ -1,0 +1,217 @@
+name: publish-windows-nsis-parity-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      promote_latest:
+        description: Also refresh the latest tag.
+        required: false
+        default: false
+        type: boolean
+      additional_tag:
+        description: Optional extra tag (for example canary or rc1).
+        required: false
+        default: ''
+        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - tools/nsis-selftest-windows/Dockerfile
+      - tools/nsis-selftest-windows/README.md
+      - scripts/Invoke-WindowsContainerNsisSelfTest.ps1
+      - scripts/Build-RunnerCliBundleFromManifest.ps1
+      - scripts/Install-WorkspaceFromManifest.ps1
+      - workspace-governance.json
+      - workspace-governance-payload/tools/cdev-cli/**
+      - .github/workflows/publish-windows-nsis-parity-image.yml
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-windows-nsis-parity-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish Windows NSIS Parity Image
+    runs-on: [self-hosted, windows, windows-containers, cdev-surface-windows-gate]
+    env:
+      IMAGE_REPO: ghcr.io/labview-community-ci-cd/labview-cdev-surface-nsis-windows-parity
+      BASE_TAG: 2026q1-windows
+      WINDOWS_DOCKER_CONTEXT: ${{ vars.WINDOWS_DOCKER_CONTEXT }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve deterministic tags
+        id: resolve
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $dateUtc = (Get-Date).ToUniversalTime().ToString('yyyyMMdd')
+          $shortSha = $env:GITHUB_SHA.Substring(0, 12).ToLowerInvariant()
+          $promoteLatest = '${{ github.event.inputs.promote_latest }}'
+          $additionalTag = '${{ github.event.inputs.additional_tag }}'
+
+          if ([string]::IsNullOrWhiteSpace($promoteLatest)) {
+            $promoteLatest = 'false'
+          }
+          if ($promoteLatest -notin @('true', 'false')) {
+            throw "promote_latest must be true or false (got '$promoteLatest')."
+          }
+          if (-not [string]::IsNullOrWhiteSpace($additionalTag) -and $additionalTag -notmatch '^[A-Za-z0-9._-]+$') {
+            throw "additional_tag must match ^[A-Za-z0-9._-]+$."
+          }
+
+          $tags = @(
+            "$env:IMAGE_REPO`:sha-$shortSha",
+            "$env:IMAGE_REPO`:$env:BASE_TAG-$dateUtc"
+          )
+          if ($promoteLatest -eq 'true') {
+            $tags += "$env:IMAGE_REPO`:latest"
+          }
+          if (-not [string]::IsNullOrWhiteSpace($additionalTag)) {
+            $tags += "$env:IMAGE_REPO`:$additionalTag"
+          }
+
+          $localImage = "labview-cdev-surface-nsis-windows-parity:selftest-$shortSha"
+
+          "date_utc=$dateUtc" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "short_sha=$shortSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "local_image=$localImage" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "tags<<EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $tags | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "EOF" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Assert Windows Docker engine
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $dockerArgs = @()
+          if (-not [string]::IsNullOrWhiteSpace($env:WINDOWS_DOCKER_CONTEXT)) {
+            $dockerArgs += @('--context', $env:WINDOWS_DOCKER_CONTEXT)
+          }
+
+          $osType = & docker @($dockerArgs + @('info', '--format', '{{.OSType}}')) 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            throw "docker_info_failed: unable to query Docker engine OSType."
+          }
+          $osTypeNormalized = ([string]$osType).Trim().ToLowerInvariant()
+          if ($osTypeNormalized -ne 'windows') {
+            throw "windows_container_mode_required: Docker engine OSType is '$osTypeNormalized'."
+          }
+
+      - name: Exercise silent installer in Windows container
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $outputRoot = Join-Path $env:GITHUB_WORKSPACE 'artifacts\release\windows-container-nsis-selftest-publish'
+          $scriptArgs = @(
+            '-NoProfile',
+            '-ExecutionPolicy', 'Bypass',
+            '-File', '.\scripts\Invoke-WindowsContainerNsisSelfTest.ps1',
+            '-Image', '${{ steps.resolve.outputs.local_image }}',
+            '-BuildLocalImage',
+            '-OutputRoot', $outputRoot
+          )
+          if (-not [string]::IsNullOrWhiteSpace($env:WINDOWS_DOCKER_CONTEXT)) {
+            $scriptArgs += @('-DockerContext', $env:WINDOWS_DOCKER_CONTEXT)
+          }
+
+          & powershell @scriptArgs
+          if ($LASTEXITCODE -ne 0) {
+            throw "Invoke-WindowsContainerNsisSelfTest.ps1 failed with exit code $LASTEXITCODE."
+          }
+
+          $reportPath = Join-Path $outputRoot 'windows-container-nsis-selftest-report.json'
+          if (-not (Test-Path -LiteralPath $reportPath -PathType Leaf)) {
+            throw "Windows self-test report missing: $reportPath"
+          }
+          $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -ErrorAction Stop
+          if ([string]$report.status -ne 'succeeded') {
+            throw "Windows self-test report status is '$([string]$report.status)' (expected 'succeeded')."
+          }
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish image tags
+        id: publish
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $localImage = '${{ steps.resolve.outputs.local_image }}'
+          $imagePresent = (& docker image inspect $localImage 2>$null)
+          if ($LASTEXITCODE -ne 0 -or -not $imagePresent) {
+            throw "Local image missing after self-test build: $localImage"
+          }
+
+          $tagsText = @'
+${{ steps.resolve.outputs.tags }}
+'@
+          $tags = @($tagsText -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+          if ($tags.Count -eq 0) {
+            throw 'No publish tags resolved.'
+          }
+
+          $digest = ''
+          foreach ($tag in $tags) {
+            & docker tag $localImage $tag
+            if ($LASTEXITCODE -ne 0) {
+              throw "docker tag failed for '$tag'."
+            }
+
+            $pushOutput = & docker push $tag 2>&1
+            if ($LASTEXITCODE -ne 0) {
+              $pushOutput | ForEach-Object { Write-Host $_ }
+              throw "docker push failed for '$tag'."
+            }
+            $pushOutput | ForEach-Object { Write-Host $_ }
+
+            $pushText = ($pushOutput | Out-String)
+            $digestMatch = [regex]::Match($pushText, 'digest:\s*(sha256:[0-9a-f]{64})')
+            if (-not $digestMatch.Success) {
+              throw "Unable to parse digest from docker push output for '$tag'."
+            }
+
+            $tagDigest = $digestMatch.Groups[1].Value.ToLowerInvariant()
+            if ([string]::IsNullOrWhiteSpace($digest)) {
+              $digest = $tagDigest
+            } elseif ($digest -ne $tagDigest) {
+              throw "Digest mismatch across tags. expected '$digest' got '$tagDigest' for '$tag'."
+            }
+          }
+
+          "digest=$digest" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Publish summary
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $tagsText = @'
+${{ steps.resolve.outputs.tags }}
+'@
+          $tags = @($tagsText -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value '## Windows NSIS Parity Image Published'
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ''
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Image: ``$env:IMAGE_REPO``"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Digest: ``${{ steps.publish.outputs.digest }}``"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Commit: ``$env:GITHUB_SHA``"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "- Silent self-test: ``Invoke-WindowsContainerNsisSelfTest.ps1`` passed"
+          Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value '- Tags:'
+          foreach ($tag in $tags) {
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value "  - ``$tag``"
+          }

--- a/README.md
+++ b/README.md
@@ -211,11 +211,18 @@ pwsh -NoProfile -File .\scripts\Invoke-WindowsContainerNsisSelfTest.ps1 `
 ```
 
 This wrapper fails fast with `windows_container_mode_required` unless Docker reports `OSType=windows`.
+The runtime stages manifest-pinned `cdev-cli` assets before building the installer, then executes the installer in silent mode (`/S`) inside the same container.
 
 Outputs are written under:
 - `artifacts\release\windows-container-nsis-selftest`
 - `container-report.json`
 - `windows-container-nsis-selftest-report.json`
+
+Publish the Windows parity image to GHCR with deterministic tags and pre-publish silent-install gating:
+- Workflow: `.github/workflows/publish-windows-nsis-parity-image.yml`
+- Image repo: `ghcr.io/labview-community-ci-cd/labview-cdev-surface-nsis-windows-parity`
+- Default tags: `sha-<12-char-commit>`, `2026q1-windows-<yyyymmdd>`
+- Optional manual tags: `latest` (`promote_latest=true`) and `additional_tag`
 
 ## Linux NSIS parity container
 

--- a/tests/WindowsNsisParityImagePublishWorkflowContract.Tests.ps1
+++ b/tests/WindowsNsisParityImagePublishWorkflowContract.Tests.ps1
@@ -1,0 +1,50 @@
+#Requires -Version 7.0
+#Requires -Modules Pester
+
+$ErrorActionPreference = 'Stop'
+
+Describe 'Windows NSIS parity image publish workflow contract' {
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path -Path (Join-Path $PSScriptRoot '..')).Path
+        $script:workflowPath = Join-Path $script:repoRoot '.github/workflows/publish-windows-nsis-parity-image.yml'
+
+        if (-not (Test-Path -LiteralPath $script:workflowPath -PathType Leaf)) {
+            throw "Windows NSIS parity image publish workflow missing: $script:workflowPath"
+        }
+
+        $script:workflowContent = Get-Content -LiteralPath $script:workflowPath -Raw
+    }
+
+    It 'supports manual dispatch and deterministic main-path publish triggers including cdev-cli payload' {
+        $script:workflowContent | Should -Match 'workflow_dispatch:'
+        $script:workflowContent | Should -Match 'push:'
+        $script:workflowContent | Should -Match 'tools/nsis-selftest-windows/Dockerfile'
+        $script:workflowContent | Should -Match 'scripts/Invoke-WindowsContainerNsisSelfTest\.ps1'
+        $script:workflowContent | Should -Match 'scripts/Build-RunnerCliBundleFromManifest\.ps1'
+        $script:workflowContent | Should -Match 'scripts/Install-WorkspaceFromManifest\.ps1'
+        $script:workflowContent | Should -Match 'workspace-governance-payload/tools/cdev-cli/\*\*'
+        $script:workflowContent | Should -Match 'workspace-governance\.json'
+    }
+
+    It 'enforces windows container preflight and silent self-test gate before publish' {
+        $script:workflowContent | Should -Match 'runs-on:\s*\[self-hosted,\s*windows,\s*windows-containers,\s*cdev-surface-windows-gate\]'
+        $script:workflowContent | Should -Match 'windows_container_mode_required'
+        $script:workflowContent | Should -Match 'Invoke-WindowsContainerNsisSelfTest\.ps1'
+        $script:workflowContent | Should -Match '-BuildLocalImage'
+        $script:workflowContent | Should -Match 'windows-container-nsis-selftest-publish'
+        $script:workflowContent | Should -Match 'Silent self-test'
+    }
+
+    It 'publishes to GHCR with package write permission and deterministic digest reporting' {
+        $script:workflowContent | Should -Match 'packages:\s*write'
+        $script:workflowContent | Should -Match 'ghcr\.io/labview-community-ci-cd/labview-cdev-surface-nsis-windows-parity'
+        $script:workflowContent | Should -Match 'docker/login-action@v3'
+        $script:workflowContent | Should -Match 'docker push'
+        $script:workflowContent | Should -Match 'sha-\$shortSha'
+        $script:workflowContent | Should -Match 'BASE_TAG:\s*2026q1-windows'
+        $script:workflowContent | Should -Match '\$env:BASE_TAG-\$dateUtc'
+        $script:workflowContent | Should -Match 'digest=\$digest'
+        $script:workflowContent | Should -Match 'digestMatch\s*=\s*\[regex\]::Match'
+        $script:workflowContent | Should -Match 'sha256:\[0-9a-f\]\{64\}'
+    }
+}

--- a/tests/WorkspaceSurfaceContract.Tests.ps1
+++ b/tests/WorkspaceSurfaceContract.Tests.ps1
@@ -46,6 +46,7 @@ Describe 'Workspace surface contract' {
         $script:releaseWithGateWorkflowPath = Join-Path $script:repoRoot '.github/workflows/release-with-windows-gate.yml'
         $script:canaryWorkflowPath = Join-Path $script:repoRoot '.github/workflows/nightly-supplychain-canary.yml'
         $script:linuxNsisParityImagePublishWorkflowPath = Join-Path $script:repoRoot '.github/workflows/publish-linux-nsis-parity-image.yml'
+        $script:windowsNsisParityImagePublishWorkflowPath = Join-Path $script:repoRoot '.github/workflows/publish-windows-nsis-parity-image.yml'
         $script:windowsImageGateWorkflowPath = Join-Path $script:repoRoot '.github/workflows/windows-labview-image-gate.yml'
         $script:windowsImageGateCoreWorkflowPath = Join-Path $script:repoRoot '.github/workflows/_windows-labview-image-gate-core.yml'
         $script:linuxImageGateWorkflowPath = Join-Path $script:repoRoot '.github/workflows/linux-labview-image-gate.yml'
@@ -103,6 +104,7 @@ Describe 'Workspace surface contract' {
             $script:releaseWithGateWorkflowPath,
             $script:canaryWorkflowPath,
             $script:linuxNsisParityImagePublishWorkflowPath,
+            $script:windowsNsisParityImagePublishWorkflowPath,
             $script:windowsImageGateWorkflowPath,
             $script:windowsImageGateCoreWorkflowPath,
             $script:linuxImageGateWorkflowPath,
@@ -380,6 +382,7 @@ Describe 'Workspace surface contract' {
         $script:ciWorkflowContent | Should -Match 'LinuxLabviewImageGateWorkflowContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'LinuxContainerNsisParityContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'LinuxNsisParityImagePublishWorkflowContract\.Tests\.ps1'
+        $script:ciWorkflowContent | Should -Match 'WindowsNsisParityImagePublishWorkflowContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'WindowsContainerNsisSelfTestContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'IsolatedBuildWorkspacePolicyContract\.Tests\.ps1'
         $script:ciWorkflowContent | Should -Match 'GitSafeDirectoryPolicyContract\.Tests\.ps1'

--- a/tools/nsis-selftest-windows/README.md
+++ b/tools/nsis-selftest-windows/README.md
@@ -5,8 +5,9 @@ This image is the local runtime for `scripts/Invoke-WindowsContainerNsisSelfTest
 ## Purpose
 
 - Build the workspace NSIS installer inside a Windows container.
-- Run the installer in the same container for smoke validation.
+- Run the installer in the same container for silent smoke validation (`/S`).
 - Validate install report output before the container exits.
+- Stage manifest-pinned `cdev-cli` payload assets before container execution.
 
 ## Included tooling
 
@@ -28,3 +29,9 @@ docker build `
   -t labview-cdev-surface-nsis-selftest:local `
   .\tools\nsis-selftest-windows
 ```
+
+## Publish from GitHub
+
+- Workflow: `.github/workflows/publish-windows-nsis-parity-image.yml`
+- Image: `ghcr.io/labview-community-ci-cd/labview-cdev-surface-nsis-windows-parity`
+- Publish is gated by `scripts/Invoke-WindowsContainerNsisSelfTest.ps1` and fails before push if silent install checks fail.


### PR DESCRIPTION
## Summary\n- add publish-windows-nsis-parity-image workflow targeting GHCR\n- gate publish with Invoke-WindowsContainerNsisSelfTest.ps1 (silent /S installer exercise)\n- include cdev-cli payload and manifest-trigger paths for deterministic rebuilds\n- add workflow contract tests and CI coverage for the new publish surface\n\n## Validation\n- Invoke-Pester -Path ./tests -CI (194 passed)\n