### PR TITLE
Lock hosted-runner CI and fix Windows publish pwsh runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Enforce hosted-runner lock
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runnerEnvironment = [string]$env:RUNNER_ENVIRONMENT
+          if ($runnerEnvironment -ne 'github-hosted') {
+            throw "hosted_runner_required: CI Pipeline must run on a github-hosted runner. actual='$runnerEnvironment'"
+          }
+
       - name: Install Pester
         shell: pwsh
         run: |

--- a/.github/workflows/publish-windows-nsis-parity-image.yml
+++ b/.github/workflows/publish-windows-nsis-parity-image.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Resolve deterministic tags
         id: resolve
-        shell: powershell
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -79,7 +79,7 @@ jobs:
 
       - name: Resolve Windows Docker context
         id: resolve_context
-        shell: powershell
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -163,7 +163,7 @@ jobs:
           "resolved_windows_docker_context=$resolvedContext" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Exercise silent installer in Windows container
-        shell: powershell
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -181,7 +181,7 @@ jobs:
             $scriptArgs += @('-DockerContext', $resolvedContext)
           }
 
-          & powershell @scriptArgs
+          & pwsh @scriptArgs
           if ($LASTEXITCODE -ne 0) {
             throw "Invoke-WindowsContainerNsisSelfTest.ps1 failed with exit code $LASTEXITCODE."
           }
@@ -204,7 +204,7 @@ jobs:
 
       - name: Publish image tags
         id: publish
-        shell: powershell
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -251,7 +251,7 @@ jobs:
           "digest=$digest" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Publish summary
-        shell: powershell
+        shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
 

--- a/.github/workflows/release-control-plane.yml
+++ b/.github/workflows/release-control-plane.yml
@@ -50,6 +50,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Enforce hosted-runner lock
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runnerEnvironment = [string]$env:RUNNER_ENVIRONMENT
+          if ($runnerEnvironment -ne 'github-hosted') {
+            throw "hosted_runner_required: release-control-plane must run on a github-hosted runner. actual='$runnerEnvironment'"
+          }
+
       - name: Execute autonomous release control plane
         shell: pwsh
         env:

--- a/tests/CiWorkflowReliabilityContract.Tests.ps1
+++ b/tests/CiWorkflowReliabilityContract.Tests.ps1
@@ -20,6 +20,13 @@ Describe 'CI workflow reliability contract' {
         $script:workflowContent | Should -Match 'cancel-in-progress:\s*true'
     }
 
+    It 'locks the contract suite to github-hosted ubuntu CI runners' {
+        $script:workflowContent | Should -Match '(?ms)ci-pipeline:\s*.*?runs-on:\s*ubuntu-latest'
+        $script:workflowContent | Should -Match 'Enforce hosted-runner lock'
+        $script:workflowContent | Should -Match 'RUNNER_ENVIRONMENT'
+        $script:workflowContent | Should -Match 'hosted_runner_required'
+    }
+
     It 'uses reusable upload-artifact retry composite for workspace installer artifacts' {
         $script:workflowContent | Should -Match 'id:\s*upload-workspace-installer-artifact'
         $script:workflowContent | Should -Match 'uses:\s*\./\.github/actions/upload-artifact-retry'

--- a/tests/ReleaseControlPlaneWorkflowContract.Tests.ps1
+++ b/tests/ReleaseControlPlaneWorkflowContract.Tests.ps1
@@ -31,6 +31,10 @@ Describe 'Release control plane workflow contract' {
     }
 
     It 'runs autonomous control-plane runtime and uploads report' {
+        $script:workflowContent | Should -Match 'runs-on:\s*ubuntu-latest'
+        $script:workflowContent | Should -Match 'Enforce hosted-runner lock'
+        $script:workflowContent | Should -Match 'RUNNER_ENVIRONMENT'
+        $script:workflowContent | Should -Match 'hosted_runner_required'
         $script:workflowContent | Should -Match 'Invoke-ReleaseControlPlane\.ps1'
         $script:workflowContent | Should -Match 'release-control-plane-report\.json'
         $script:workflowContent | Should -Match 'Release Control Plane Alert'


### PR DESCRIPTION
## Summary
- enforce github-hosted runner lock in ci.yml
- enforce github-hosted runner lock in elease-control-plane.yml
- switch Windows parity publish workflow steps to pwsh and invoke self-test with pwsh
- extend CI/release control plane contract tests for hosted-runner lock

## Validation
- Invoke-Pester -Path ./tests -CI (195/195 passing)