### PR TITLE
Stabilize cdev-cli-driven Windows container installer smoke

### DIFF
--- a/nsis/workspace-bootstrap-installer.nsi
+++ b/nsis/workspace-bootstrap-installer.nsi
@@ -95,6 +95,13 @@ Section "Install"
     Goto labview_x86_ready
   ${EndIf}
 
+  !if "${INSTALL_EXEC_CONTEXT}" == "ContainerSmoke"
+    FileOpen $2 "${WORKSPACE_ROOT}\${LAUNCH_LOG_REL}" a
+    FileWrite $2 "x86_bootstrap_skipped_for_container_smoke=true$\r$\n"
+    FileClose $2
+    Goto labview_x86_ready
+  !endif
+
   IfFileExists "$4" labview_x86_ready 0
   ReadEnvStr $5 "${X86_NIPKG_ENV}"
   FileOpen $2 "${WORKSPACE_ROOT}\${LAUNCH_LOG_REL}" a


### PR DESCRIPTION
## Summary
- skip x86 NI Package Manager bootstrap when installer execution context is ContainerSmoke
- harden Windows container self-test runtime for mounted workspace roots and cdev-cli report-path behavior
- safely consume cdev-cli run report fields under strict mode
- persist workspace mirror from container for deterministic diagnostics
- extend container self-test contract to assert ContainerSmoke bootstrap skip in NSIS script

## Validation
- Invoke-Pester -Path ./tests -CI (196/196 passing)
- local Invoke-WindowsContainerNsisSelfTest.ps1 run succeeded (cdev-cli installer operation in container)