### PR TITLE
Fix control-plane runner label argument passing

### DIFF
--- a/scripts/Exercise-ReleaseControlPlaneLocal.ps1
+++ b/scripts/Exercise-ReleaseControlPlaneLocal.ps1
@@ -96,11 +96,12 @@ function Add-StepResult {
 
 try {
     $releaseRunnerLabels = @('self-hosted', 'windows', 'self-hosted-windows-lv')
+    $releaseRunnerLabelsCsv = [string]::Join(',', $releaseRunnerLabels)
 
     $opsSnapshotPath = Join-Path $resolvedOutputRoot 'ops-monitoring-report.json'
     & pwsh -NoProfile -File $opsSnapshotScript `
         -SurfaceRepository $Repository `
-        -RequiredRunnerLabels $releaseRunnerLabels `
+        -RequiredRunnerLabelsCsv $releaseRunnerLabelsCsv `
         -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
         -OutputPath $opsSnapshotPath
     if ($LASTEXITCODE -ne 0) {
@@ -112,7 +113,7 @@ try {
         $opsRemediatePath = Join-Path $resolvedOutputRoot 'ops-autoremediate-report.json'
         & pwsh -NoProfile -File $opsRemediateScript `
             -SurfaceRepository $Repository `
-            -RequiredRunnerLabels $releaseRunnerLabels `
+            -RequiredRunnerLabelsCsv $releaseRunnerLabelsCsv `
             -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
             -OutputPath $opsRemediatePath
         if ($LASTEXITCODE -ne 0) {

--- a/scripts/Invoke-OpsMonitoringSnapshot.ps1
+++ b/scripts/Invoke-OpsMonitoringSnapshot.ps1
@@ -17,6 +17,9 @@ param(
     ),
 
     [Parameter()]
+    [string]$RequiredRunnerLabelsCsv = '',
+
+    [Parameter()]
     [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
     [string]$SyncGuardRepository = 'LabVIEW-Community-CI-CD/labview-cdev-cli',
 
@@ -40,6 +43,14 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'lib/WorkflowOps.Common.ps1')
+
+if (-not [string]::IsNullOrWhiteSpace($RequiredRunnerLabelsCsv)) {
+    $RequiredRunnerLabels = @(
+        $RequiredRunnerLabelsCsv.Split(',') |
+            ForEach-Object { ([string]$_).Trim() } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    )
+}
 
 function Convert-RunRecord {
     param([Parameter(Mandatory = $true)][object]$Run)

--- a/scripts/Invoke-ReleaseControlPlane.ps1
+++ b/scripts/Invoke-ReleaseControlPlane.ps1
@@ -50,6 +50,7 @@ $dispatchWorkflowScript = Join-Path $PSScriptRoot 'Dispatch-WorkflowAtRemoteHead
 $watchWorkflowScript = Join-Path $PSScriptRoot 'Watch-WorkflowRun.ps1'
 $canaryHygieneScript = Join-Path $PSScriptRoot 'Invoke-CanarySmokeTagHygiene.ps1'
 $releaseRunnerLabels = @('self-hosted', 'windows', 'self-hosted-windows-lv')
+$releaseRunnerLabelsCsv = [string]::Join(',', $releaseRunnerLabels)
 
 foreach ($requiredScript in @($opsSnapshotScript, $opsRemediateScript, $dispatchWorkflowScript, $watchWorkflowScript, $canaryHygieneScript)) {
     if (-not (Test-Path -LiteralPath $requiredScript -PathType Leaf)) {
@@ -348,7 +349,7 @@ try {
     try {
         & pwsh -NoProfile -File $opsSnapshotScript `
             -SurfaceRepository $Repository `
-            -RequiredRunnerLabels $releaseRunnerLabels `
+            -RequiredRunnerLabelsCsv $releaseRunnerLabelsCsv `
             -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
             -OutputPath $preHealthPath
         if ($LASTEXITCODE -eq 0) {
@@ -366,7 +367,7 @@ try {
         $remediationPath = Join-Path $scratchRoot 'remediation.json'
         & pwsh -NoProfile -File $opsRemediateScript `
             -SurfaceRepository $Repository `
-            -RequiredRunnerLabels $releaseRunnerLabels `
+            -RequiredRunnerLabelsCsv $releaseRunnerLabelsCsv `
             -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
             -OutputPath $remediationPath
         if (Test-Path -LiteralPath $remediationPath -PathType Leaf) {
@@ -377,7 +378,7 @@ try {
     $postHealthPath = Join-Path $scratchRoot 'post-health.json'
     & pwsh -NoProfile -File $opsSnapshotScript `
         -SurfaceRepository $Repository `
-        -RequiredRunnerLabels $releaseRunnerLabels `
+        -RequiredRunnerLabelsCsv $releaseRunnerLabelsCsv `
         -SyncGuardMaxAgeHours $SyncGuardMaxAgeHours `
         -OutputPath $postHealthPath
     if ($LASTEXITCODE -ne 0) {

--- a/tests/OpsAutoRemediationWorkflowContract.Tests.ps1
+++ b/tests/OpsAutoRemediationWorkflowContract.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'Ops auto-remediation workflow contract' {
 
     It 'uses release-runner labels for control-plane remediation health checks' {
         $script:runtimeContent | Should -Match "self-hosted',\s*'windows',\s*'self-hosted-windows-lv"
-        $script:runtimeContent | Should -Match 'RequiredRunnerLabels \$RequiredRunnerLabels'
+        $script:runtimeContent | Should -Match 'RequiredRunnerLabelsCsv \$requiredRunnerLabelsCsv'
         $script:runtimeContent | Should -Not -Match 'windows-containers'
         $script:runtimeContent | Should -Not -Match 'user-session'
         $script:runtimeContent | Should -Not -Match 'cdev-surface-windows-gate'

--- a/tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1
+++ b/tests/ReleaseControlPlaneLocalDockerHarnessContract.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Release control plane local Docker harness contract' {
         $script:harnessContent | Should -Match 'Invoke-OpsAutoRemediation\.ps1'
         $script:harnessContent | Should -Match 'Invoke-ReleaseControlPlane\.ps1'
         $script:harnessContent | Should -Match 'Write-OpsSloReport\.ps1'
-        $script:harnessContent | Should -Match 'RequiredRunnerLabels \$releaseRunnerLabels'
+        $script:harnessContent | Should -Match 'RequiredRunnerLabelsCsv \$releaseRunnerLabelsCsv'
         $script:harnessContent | Should -Match "self-hosted', 'windows', 'self-hosted-windows-lv"
         $script:harnessContent | Should -Match 'release-control-plane-local-summary\.json'
     }

--- a/tests/ReleaseControlPlaneWorkflowContract.Tests.ps1
+++ b/tests/ReleaseControlPlaneWorkflowContract.Tests.ps1
@@ -58,7 +58,7 @@ Describe 'Release control plane workflow contract' {
     }
 
     It 'decouples control-plane runner health gate to release-runner labels' {
-        $script:runtimeContent | Should -Match 'RequiredRunnerLabels \$releaseRunnerLabels'
+        $script:runtimeContent | Should -Match 'RequiredRunnerLabelsCsv \$releaseRunnerLabelsCsv'
         $script:runtimeContent | Should -Match "self-hosted', 'windows', 'self-hosted-windows-lv"
         $script:runtimeContent | Should -Not -Match 'windows-containers'
         $script:runtimeContent | Should -Not -Match 'user-session'


### PR DESCRIPTION
## Summary\n- fix release-runner label passing across pwsh -File boundaries for ops health scripts\n- add RequiredRunnerLabelsCsv handling in Invoke-OpsMonitoringSnapshot.ps1 and normalize labels before use\n- update release-control-plane, ops-autoremediation, and local harness callers to pass deterministic CSV label payloads\n- keep strict default label model in Invoke-OpsMonitoringSnapshot.ps1 unchanged for ops-monitoring.yml\n- update workflow contract tests for the CSV path\n\n## Validation\n- Invoke-Pester -Path ./tests -CI (198 passed, 0 failed)\n- elease-control-plane.yml workflow_dispatch on this branch (mode=Validate, dry_run=true)\n  - run: https://github.com/LabVIEW-Community-CI-CD/labview-cdev-surface-fork/actions/runs/22470890728\n  - result: success\n