### PR TITLE
Fix self-healing dispatch input binding

### DIFF
--- a/scripts/Dispatch-WorkflowAtRemoteHead.ps1
+++ b/scripts/Dispatch-WorkflowAtRemoteHead.ps1
@@ -11,7 +11,8 @@ param(
     [string]$Branch = 'main',
 
     [Parameter()]
-    [string[]]$Input = @(),
+    [Alias('Input')]
+    [string[]]$Inputs = @(),
 
     [Parameter()]
     [switch]$CancelStale,
@@ -53,7 +54,7 @@ if ($CancelStale) {
 
 $dispatchStartedUtc = (Get-Date).ToUniversalTime()
 $dispatchArgs = @('workflow', 'run', $WorkflowFile, '-R', $Repository, '--ref', $Branch)
-$dispatchArgs += @(Convert-InputPairsToGhArgs -Input $Input)
+$dispatchArgs += @(Convert-InputPairsToGhArgs -Inputs $Inputs)
 Invoke-Gh -Arguments $dispatchArgs
 
 Start-Sleep -Seconds $DispatchPauseSeconds
@@ -91,7 +92,7 @@ $report = [ordered]@{
     status = [string]$selectedRun.status
     conclusion = [string]$selectedRun.conclusion
     url = [string]$selectedRun.url
-    inputs = @($Input)
+    inputs = @($Inputs)
     stale_cancel_report = $cancelReport
 }
 

--- a/scripts/Invoke-OpsSloSelfHealing.ps1
+++ b/scripts/Invoke-OpsSloSelfHealing.ps1
@@ -173,15 +173,13 @@ try {
             $executionOk = $true
             try {
                 $dispatchPath = Join-Path $scratchRoot ("attempt-{0}-dispatch.json" -f $attempt)
-                & pwsh -NoProfile -File $dispatchWorkflowScript `
+                $dispatchInputs = @("sync_guard_max_age_hours=$SyncGuardMaxAgeHours")
+                & $dispatchWorkflowScript `
                     -Repository $SurfaceRepository `
                     -WorkflowFile $RemediationWorkflow `
                     -Branch $RemediationBranch `
-                    -Input @("sync_guard_max_age_hours=$SyncGuardMaxAgeHours") `
+                    -Inputs $dispatchInputs `
                     -OutputPath $dispatchPath | Out-Null
-                if ($LASTEXITCODE -ne 0) {
-                    throw "slo_remediation_dispatch_failed: exit_code=$LASTEXITCODE"
-                }
                 $dispatchReport = Get-Content -LiteralPath $dispatchPath -Raw | ConvertFrom-Json -ErrorAction Stop
                 $attemptRecord.dispatch = [ordered]@{
                     run_id = [string]$dispatchReport.run_id

--- a/scripts/Invoke-ReleaseControlPlane.ps1
+++ b/scripts/Invoke-ReleaseControlPlane.ps1
@@ -270,20 +270,18 @@ function Invoke-ReleaseMode {
     }
 
     $dispatchReportPath = Join-Path $ScratchRoot "$ModeName-dispatch.json"
-    & pwsh -NoProfile -File $dispatchWorkflowScript `
+    $dispatchInputs = @(
+        "release_tag=$targetTag",
+        'allow_existing_tag=false',
+        "prerelease=$([string]([bool]$modeConfig.prerelease).ToLowerInvariant())",
+        "release_channel=$([string]$modeConfig.channel)"
+    )
+    & $dispatchWorkflowScript `
         -Repository $Repository `
         -WorkflowFile $ReleaseWorkflowFile `
         -Branch $Branch `
-        -Input @(
-            "release_tag=$targetTag",
-            'allow_existing_tag=false',
-            "prerelease=$([string]([bool]$modeConfig.prerelease).ToLowerInvariant())",
-            "release_channel=$([string]$modeConfig.channel)"
-        ) `
+        -Inputs $dispatchInputs `
         -OutputPath $dispatchReportPath
-    if ($LASTEXITCODE -ne 0) {
-        throw "release_dispatch_failed: mode=$ModeName exit_code=$LASTEXITCODE"
-    }
     $dispatchReport = Get-Content -LiteralPath $dispatchReportPath -Raw | ConvertFrom-Json -ErrorAction Stop
 
     $watchReportPath = Join-Path $ScratchRoot "$ModeName-watch.json"

--- a/scripts/Invoke-RollbackDrillSelfHealing.ps1
+++ b/scripts/Invoke-RollbackDrillSelfHealing.ps1
@@ -270,20 +270,18 @@ try {
                     $attemptRecord.target_tag = [string]$targetTagRecord.tag
 
                     $dispatchPath = Join-Path $scratchRoot ("attempt-{0}-dispatch.json" -f $attempt)
-                    & pwsh -NoProfile -File $dispatchWorkflowScript `
+                    $dispatchInputs = @(
+                        "release_tag=$([string]$targetTagRecord.tag)",
+                        'allow_existing_tag=false',
+                        'prerelease=true',
+                        'release_channel=canary'
+                    )
+                    & $dispatchWorkflowScript `
                         -Repository $Repository `
                         -WorkflowFile $ReleaseWorkflowFile `
                         -Branch $Branch `
-                        -Input @(
-                            "release_tag=$([string]$targetTagRecord.tag)",
-                            'allow_existing_tag=false',
-                            'prerelease=true',
-                            'release_channel=canary'
-                        ) `
+                        -Inputs $dispatchInputs `
                         -OutputPath $dispatchPath | Out-Null
-                    if ($LASTEXITCODE -ne 0) {
-                        throw "rollback_auto_release_dispatch_failed: exit_code=$LASTEXITCODE"
-                    }
                     $dispatchReport = Get-Content -LiteralPath $dispatchPath -Raw | ConvertFrom-Json -ErrorAction Stop
                     $attemptRecord.dispatch = [ordered]@{
                         run_id = [string]$dispatchReport.run_id

--- a/scripts/lib/WorkflowOps.Common.ps1
+++ b/scripts/lib/WorkflowOps.Common.ps1
@@ -72,10 +72,14 @@ function Get-UtcNowIso {
 }
 
 function Convert-InputPairsToGhArgs {
-    param([Parameter()][string[]]$Input = @())
+    param(
+        [Parameter()]
+        [Alias('Input')]
+        [string[]]$Inputs = @()
+    )
 
     $arguments = @()
-    foreach ($pair in @($Input)) {
+    foreach ($pair in @($Inputs)) {
         $text = ([string]$pair).Trim()
         if ([string]::IsNullOrWhiteSpace($text)) {
             continue

--- a/tests/DispatchWorkflowAtRemoteHeadContract.Tests.ps1
+++ b/tests/DispatchWorkflowAtRemoteHeadContract.Tests.ps1
@@ -18,6 +18,12 @@ Describe 'Dispatch workflow at remote head contract' {
         $script:content | Should -Match 'dispatch_head_sha_mismatch'
     }
 
+    It 'uses explicit inputs parameter with backward-compatible alias' {
+        $script:content | Should -Match "\[Alias\('Input'\)\]"
+        $script:content | Should -Match '\[string\[\]\]\$Inputs'
+        $script:content | Should -Match 'Convert-InputPairsToGhArgs -Inputs \$Inputs'
+    }
+
     It 'supports stale-run cancellation before dispatch' {
         $script:content | Should -Match 'Cancel-StaleWorkflowRuns\.ps1'
         $script:content | Should -Match '-TargetHeadSha \$expectedHeadSha'

--- a/tests/OpsSloGateWorkflowContract.Tests.ps1
+++ b/tests/OpsSloGateWorkflowContract.Tests.ps1
@@ -59,6 +59,8 @@ Describe 'Ops SLO gate workflow contract' {
         $script:selfHealingContent | Should -Match 'Dispatch-WorkflowAtRemoteHead\.ps1'
         $script:selfHealingContent | Should -Match 'Watch-WorkflowRun\.ps1'
         $script:selfHealingContent | Should -Match 'ops-autoremediate\.yml'
+        $script:selfHealingContent | Should -Match '\$dispatchInputs = @\('
+        $script:selfHealingContent | Should -Match '-Inputs \$dispatchInputs'
         $script:selfHealingContent | Should -Match 'sync_guard_max_age_hours'
         $script:selfHealingContent | Should -Match 'already_healthy'
         $script:selfHealingContent | Should -Match 'remediated'

--- a/tests/ReleaseControlPlaneWorkflowContract.Tests.ps1
+++ b/tests/ReleaseControlPlaneWorkflowContract.Tests.ps1
@@ -58,6 +58,8 @@ Describe 'Release control plane workflow contract' {
         $script:runtimeContent | Should -Match 'promotion_source_not_at_head'
         $script:runtimeContent | Should -Match 'release_tag_range_exhausted'
         $script:runtimeContent | Should -Match 'Invoke-CanarySmokeTagHygiene\.ps1'
+        $script:runtimeContent | Should -Match '\$dispatchInputs = @\('
+        $script:runtimeContent | Should -Match '-Inputs \$dispatchInputs'
     }
 
     It 'decouples control-plane runner health gate to release-runner labels' {

--- a/tests/ReleaseRollbackDrillWorkflowContract.Tests.ps1
+++ b/tests/ReleaseRollbackDrillWorkflowContract.Tests.ps1
@@ -57,6 +57,8 @@ Describe 'Release rollback drill workflow contract' {
         $script:selfHealingContent | Should -Match 'Invoke-ReleaseRollbackDrill\.ps1'
         $script:selfHealingContent | Should -Match 'Dispatch-WorkflowAtRemoteHead\.ps1'
         $script:selfHealingContent | Should -Match 'Watch-WorkflowRun\.ps1'
+        $script:selfHealingContent | Should -Match '\$dispatchInputs = @\('
+        $script:selfHealingContent | Should -Match '-Inputs \$dispatchInputs'
         $script:selfHealingContent | Should -Match 'release-workspace-installer\.yml'
         $script:selfHealingContent | Should -Match 'release_channel=canary'
         $script:selfHealingContent | Should -Match 'allow_existing_tag=false'


### PR DESCRIPTION
## Summary\n- fix PowerShell dispatch input binding in release-control and self-healing flows\n- rename dispatch input parameter to \Inputs\ with backward-compatible alias \Input\\n- pass dispatch inputs explicitly via variables and call dispatch script in-process to avoid native argument rebinding\n- add contract assertions to prevent regression\n\n## Validation\n- \\Invoke-Pester -Path ./tests -CI\\ (213 passed, 0 failed)