### PR TITLE
Fix release preflight runner-label argument binding

### DIFF
--- a/.github/workflows/_release-workspace-installer-core.yml
+++ b/.github/workflows/_release-workspace-installer-core.yml
@@ -62,7 +62,7 @@ jobs:
           try {
             & pwsh -NoProfile -File ./scripts/Invoke-OpsMonitoringSnapshot.ps1 `
               -SurfaceRepository '${{ github.repository }}' `
-              -RequiredRunnerLabels @('self-hosted', 'windows', 'self-hosted-windows-lv') `
+              -RequiredRunnerLabelsCsv 'self-hosted,windows,self-hosted-windows-lv' `
               -OutputPath $reportPath
             if ($LASTEXITCODE -ne 0) {
               throw 'Ops monitoring snapshot returned non-zero exit.'

--- a/tests/WorkspaceInstallerReleaseContract.Tests.ps1
+++ b/tests/WorkspaceInstallerReleaseContract.Tests.ps1
@@ -49,6 +49,7 @@ Describe 'Workspace installer release workflow contract' {
         $script:coreWorkflowContent | Should -Match 'name:\s*Release Ops Health Preflight'
         $script:coreWorkflowContent | Should -Match 'Enforce ops health preflight'
         $script:coreWorkflowContent | Should -Match 'Invoke-OpsMonitoringSnapshot\.ps1'
+        $script:coreWorkflowContent | Should -Match 'RequiredRunnerLabelsCsv ''self-hosted,windows,self-hosted-windows-lv'''
         $script:coreWorkflowContent | Should -Match 'reason_code=ops_unhealthy'
         $script:coreWorkflowContent | Should -Match '\[ops_unhealthy\]'
         $script:coreWorkflowContent | Should -Match 'release-ops-health-preflight-\$\{\{\s*github\.run_id\s*\}\}'


### PR DESCRIPTION
## Summary\n- fix _release-workspace-installer-core.yml preflight call to pass runner labels via \RequiredRunnerLabelsCsv\\n- prevent cross-process array argument rebinding into \SyncGuardRepository\\n- add contract assertion in workspace installer release workflow test\n\n## Validation\n- \\Invoke-Pester -Path ./tests -CI\\ (216 passed, 0 failed)\n- confirmed previous rollback self-heal dispatch progressed into release workflow and exposed this preflight issue