### PR TITLE
Allow rollback self-healing when latest canary assets are missing

### DIFF
--- a/scripts/Invoke-RollbackDrillSelfHealing.ps1
+++ b/scripts/Invoke-RollbackDrillSelfHealing.ps1
@@ -236,7 +236,13 @@ try {
         $report.message = 'Rollback drill failed and auto-remediation is disabled.'
     } else {
         $initialReasons = @($initialReport.reason_codes | ForEach-Object { [string]$_ })
-        $canAutomate = (($initialReasons -contains 'rollback_candidate_missing') -and ([string]$Channel -eq 'canary'))
+        $canAutomate = (
+            ([string]$Channel -eq 'canary') -and
+            (
+                ($initialReasons -contains 'rollback_candidate_missing') -or
+                ($initialReasons -contains 'rollback_assets_missing')
+            )
+        )
         if (-not $canAutomate) {
             $report.status = 'fail'
             $report.reason_code = 'no_automatable_action'

--- a/tests/ReleaseRollbackDrillWorkflowContract.Tests.ps1
+++ b/tests/ReleaseRollbackDrillWorkflowContract.Tests.ps1
@@ -63,6 +63,7 @@ Describe 'Release rollback drill workflow contract' {
         $script:selfHealingContent | Should -Match 'release_channel=canary'
         $script:selfHealingContent | Should -Match 'allow_existing_tag=false'
         $script:selfHealingContent | Should -Match 'rollback_candidate_missing'
+        $script:selfHealingContent | Should -Match 'rollback_assets_missing'
         $script:selfHealingContent | Should -Match 'already_ready'
         $script:selfHealingContent | Should -Match 'remediated'
         $script:selfHealingContent | Should -Match 'no_automatable_action'


### PR DESCRIPTION
## Summary\n- treat ollback_assets_missing as automatable for canary rollback self-healing\n- remediation now dispatches next deterministic canary release tag for both missing-candidate and missing-assets cases\n- update rollback self-healing contract test coverage\n\n## Validation\n- \\Invoke-Pester -Path ./tests -CI\\ (216 passed, 0 failed)\n- latest rollback drill run now reports ollback_assets_missing with two candidates, showing the correct next automation target