### PR TITLE
Fix local composite action usage in runner preflight job

### DIFF
--- a/.github/workflows/_release-workspace-installer-core.yml
+++ b/.github/workflows/_release-workspace-installer-core.yml
@@ -88,6 +88,9 @@ jobs:
     outputs:
       reason_code: ${{ steps.check.outputs.reason_code }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - id: check
         name: Validate eligible self-hosted release runner availability
         uses: ./.github/actions/runner-preflight

--- a/tests/WorkspaceInstallerReleaseContract.Tests.ps1
+++ b/tests/WorkspaceInstallerReleaseContract.Tests.ps1
@@ -60,6 +60,7 @@ Describe 'Workspace installer release workflow contract' {
         $script:coreWorkflowContent | Should -Match 'release-ops-health-preflight-\$\{\{\s*github\.run_id\s*\}\}'
         $script:coreWorkflowContent | Should -Match 'name:\s*Release Runner Availability Preflight'
         $script:coreWorkflowContent | Should -Match 'Validate eligible self-hosted release runner availability'
+        $script:coreWorkflowContent | Should -Match '(?s)runner_preflight:.*?-\s*name:\s*Checkout.*?actions/checkout@v4.*?-\s*id:\s*check'
         $script:coreWorkflowContent | Should -Match 'uses:\s*\./\.github/actions/runner-preflight'
         $script:coreWorkflowContent | Should -Match 'required_labels_csv:\s*self-hosted,windows,self-hosted-windows-lv'
         $script:runnerPreflightActionContent | Should -Match 'repos/\$repo/actions/runners\?per_page=100'


### PR DESCRIPTION
## Summary\n- add ctions/checkout@v4 before invoking local composite action .github/actions/runner-preflight\n- update release workflow contract test to ensure checkout precedes the local action step\n\n## Validation\n- \\Invoke-Pester -Path ./tests -CI\\ (216 passed, 0 failed)\n- release workflow failure showed missing local action files without checkout