### PR TITLE
fix: immutable-safe release asset publishing

### DIFF
--- a/.github/workflows/_release-workspace-installer-core.yml
+++ b/.github/workflows/_release-workspace-installer-core.yml
@@ -546,14 +546,15 @@ jobs:
           }
 
           $releaseTitle = "Workspace Installer $releaseTag"
+          $releaseAssets = @($assetPath, $shaPath, $reproPath, $spdxPath, $slsaPath, $releaseManifestPath)
 
           if (-not $releaseExists) {
             if ($prerelease) {
-              & gh release create $releaseTag -R $repo --target $releaseTargetSha --title $releaseTitle --notes-file $releaseNotesPath --prerelease
+              & gh release create $releaseTag $releaseAssets -R $repo --target $releaseTargetSha --title $releaseTitle --notes-file $releaseNotesPath --prerelease
             } else {
-              & gh release create $releaseTag -R $repo --target $releaseTargetSha --title $releaseTitle --notes-file $releaseNotesPath
+              & gh release create $releaseTag $releaseAssets -R $repo --target $releaseTargetSha --title $releaseTitle --notes-file $releaseNotesPath
             }
-            if ($LASTEXITCODE -ne 0) { throw "Failed to create release '$releaseTag' for '$repo'." }
+            if ($LASTEXITCODE -ne 0) { throw "Failed to create release '$releaseTag' for '$repo' with assets." }
           } else {
             if ($prerelease) {
               & gh release edit $releaseTag -R $repo --title $releaseTitle --notes-file $releaseNotesPath --prerelease
@@ -561,13 +562,15 @@ jobs:
               & gh release edit $releaseTag -R $repo --title $releaseTitle --notes-file $releaseNotesPath
             }
             if ($LASTEXITCODE -ne 0) { throw "Failed to edit release '$releaseTag' for '$repo'." }
-          }
 
-          if ($allowExistingTag) {
-            & gh release upload $releaseTag $assetPath $shaPath $reproPath $spdxPath $slsaPath $releaseManifestPath -R $repo --clobber
-          } else {
-            & gh release upload $releaseTag $assetPath $shaPath $reproPath $spdxPath $slsaPath $releaseManifestPath -R $repo
-          }
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to upload release assets for '$releaseTag'."
+            if ($allowExistingTag) {
+              $uploadOutput = & gh release upload $releaseTag $releaseAssets -R $repo --clobber 2>&1
+              if ($LASTEXITCODE -ne 0) {
+                $uploadText = ($uploadOutput | Out-String).Trim()
+                if ($uploadText -match '(?i)immutable release') {
+                  throw "[release_immutable] Release tag '$releaseTag' is immutable and cannot be overwritten. Publish a new semantic tag."
+                }
+                throw "Failed to upload release assets for '$releaseTag': $uploadText"
+              }
+            }
           }

--- a/tests/WorkspaceInstallerReleaseContract.Tests.ps1
+++ b/tests/WorkspaceInstallerReleaseContract.Tests.ps1
@@ -98,12 +98,14 @@ Describe 'Workspace installer release workflow contract' {
         $script:coreWorkflowContent | Should -Match 'Parity artifact path was selected for release publish input'
         $script:coreWorkflowContent | Should -Match 'workspace-installer-release-\$\{\{\s*github\.run_id\s*\}\}'
         $script:coreWorkflowContent | Should -Match '(gh release create|''release'',\s*''create'')'
+        $script:coreWorkflowContent | Should -Match '\$releaseAssets = @\(\$assetPath, \$shaPath, \$reproPath, \$spdxPath, \$slsaPath, \$releaseManifestPath\)'
         $script:coreWorkflowContent | Should -Match '--target \$releaseTargetSha'
         $script:coreWorkflowContent | Should -Match 'RELEASE_TARGET_SHA:\s*\$\{\{\s*github\.sha\s*\}\}'
         $script:coreWorkflowContent | Should -Match 'already exists'
         $script:coreWorkflowContent | Should -Match 'allow_existing_tag=true'
         $script:coreWorkflowContent | Should -Match 'gh release upload'
         $script:coreWorkflowContent | Should -Match '--clobber'
+        $script:coreWorkflowContent | Should -Match '\[release_immutable\]'
     }
 
     It 'enforces release notes, tag validation, and override disclosure support' {


### PR DESCRIPTION
## Summary
- attach installer assets during gh release create for new tags
- keep break-glass overwrite path for existing tags only
- emit deterministic [release_immutable] failure when overwrite is attempted against immutable releases

## Validation
- Invoke-Pester -Path ./tests/WorkspaceInstallerReleaseContract.Tests.ps1 -CI
- Invoke-Pester -Path ./tests -CI