### PR TITLE
fix: restore release workflow dispatch parsing

### DIFF
--- a/.github/workflows/_release-workspace-installer-core.yml
+++ b/.github/workflows/_release-workspace-installer-core.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       release_tag:
-        description: Release tag to publish (SemVer preferred: vX.Y.Z / vX.Y.Z-rc.N / vX.Y.Z-canary.N; legacy migration: v0.YYYYMMDD.N).
+        description: "Release tag to publish (SemVer preferred: vX.Y.Z / vX.Y.Z-rc.N / vX.Y.Z-canary.N; legacy migration: v0.YYYYMMDD.N)."
         required: true
         type: string
       allow_existing_tag:

--- a/.github/workflows/release-with-windows-gate.yml
+++ b/.github/workflows/release-with-windows-gate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag to publish (SemVer preferred: vX.Y.Z / vX.Y.Z-rc.N / vX.Y.Z-canary.N; legacy migration: v0.YYYYMMDD.N).
+        description: "Release tag to publish (SemVer preferred: vX.Y.Z / vX.Y.Z-rc.N / vX.Y.Z-canary.N; legacy migration: v0.YYYYMMDD.N)."
         required: true
         type: string
       allow_existing_tag:

--- a/.github/workflows/release-workspace-installer.yml
+++ b/.github/workflows/release-workspace-installer.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Release tag to publish (SemVer preferred: vX.Y.Z / vX.Y.Z-rc.N / vX.Y.Z-canary.N; legacy migration: v0.YYYYMMDD.N).
+        description: "Release tag to publish (SemVer preferred: vX.Y.Z / vX.Y.Z-rc.N / vX.Y.Z-canary.N; legacy migration: v0.YYYYMMDD.N)."
         required: true
         type: string
       allow_existing_tag:


### PR DESCRIPTION
## Summary
- quote release-tag input descriptions in release workflow wrappers/core
- avoids workflow parsing regression that blocked workflow_dispatch

## Validation
- Invoke-Pester -Path ./tests/WorkspaceInstallerReleaseContract.Tests.ps1,./tests/ReleaseWithWindowsGateWorkflowContract.Tests.ps1 -CI