### PR TITLE
Fix control-plane prerelease dispatch bool serialization

### DIFF
--- a/scripts/Invoke-ReleaseControlPlane.ps1
+++ b/scripts/Invoke-ReleaseControlPlane.ps1
@@ -628,7 +628,7 @@ function Invoke-ReleaseMode {
     $dispatchInputs = @(
         "release_tag=$targetTag",
         'allow_existing_tag=false',
-        "prerelease=$([string]([bool]$modeConfig.prerelease).ToLowerInvariant())",
+        "prerelease=$(([string]([bool]$modeConfig.prerelease)).ToLowerInvariant())",
         "release_channel=$([string]$modeConfig.channel)"
     )
     & $dispatchWorkflowScript `


### PR DESCRIPTION
Fixes bool-to-lowercase dispatch formatting in Invoke-ReleaseControlPlane.ps1 so CanaryCycle dispatch no longer fails at runtime.