### PR TITLE
Fix stable override audit field extraction

### DIFF
--- a/scripts/Invoke-ReleaseControlPlane.ps1
+++ b/scripts/Invoke-ReleaseControlPlane.ps1
@@ -1024,6 +1024,13 @@ function Write-StableOverrideAuditReport {
             return $DefaultValue
         }
 
+        if ($Object -is [System.Collections.IDictionary]) {
+            if ($Object.Contains($Name)) {
+                return $Object[$Name]
+            }
+            return $DefaultValue
+        }
+
         $prop = $Object.PSObject.Properties[$Name]
         if ($null -eq $prop) {
             return $DefaultValue


### PR DESCRIPTION
## Summary
- fix Write-StableOverrideAuditReport property extraction for hashtable-backed report objects
- preserve existing strict-mode-safe behavior while correctly reading nested override decision fields

## Validation
- Invoke-Pester -Path ./tests -CI (216/216)
- local dry-run FullCycle with forced override confirms:
  - override_reference and override_summary populated in override audit
  - status=override_applied and eason_code=stable_window_override_applied
