### PR TITLE
Drill: deterministic forced control-plane timeout mode

### DIFF
--- a/.github/workflows/release-race-hardening-drill.yml
+++ b/.github/workflows/release-race-hardening-drill.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: '120'
         type: string
+      force_control_plane_watch_timeout:
+        description: Force a deterministic control-plane watch-timeout failure for incident-path drills.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -77,12 +82,19 @@ jobs:
             $autoRemediate = [System.Convert]::ToBoolean($autoRemediateText)
           }
 
+          $forceControlPlaneWatchTimeoutText = [string]'${{ inputs.force_control_plane_watch_timeout }}'
+          $forceControlPlaneWatchTimeout = $false
+          if (-not [string]::IsNullOrWhiteSpace($forceControlPlaneWatchTimeoutText)) {
+            $forceControlPlaneWatchTimeout = [System.Convert]::ToBoolean($forceControlPlaneWatchTimeoutText)
+          }
+
           & pwsh -NoProfile -File ./scripts/Invoke-ReleaseRaceHardeningDrill.ps1 `
             -Repository '${{ github.repository }}' `
             -Branch 'main' `
             -AutoRemediate:$autoRemediate `
             -KeepLatestCanaryN $keepLatestCanaryN `
             -WatchTimeoutMinutes $watchTimeoutMinutes `
+            -ForceControlPlaneWatchTimeout:$forceControlPlaneWatchTimeout `
             -OutputPath $reportPath
 
       - name: Upload release race-hardening drill report

--- a/scripts/Invoke-ReleaseRaceHardeningDrill.ps1
+++ b/scripts/Invoke-ReleaseRaceHardeningDrill.ps1
@@ -33,6 +33,9 @@ param(
     [bool]$AutoRemediate = $true,
 
     [Parameter()]
+    [bool]$ForceControlPlaneWatchTimeout = $false,
+
+    [Parameter()]
     [string]$OutputPath = ''
 )
 
@@ -337,6 +340,7 @@ $report = [ordered]@{
     release_limit = $ReleaseLimit
     watch_timeout_minutes = $WatchTimeoutMinutes
     auto_remediate = [bool]$AutoRemediate
+    force_control_plane_watch_timeout = [bool]$ForceControlPlaneWatchTimeout
     keep_latest_canary_n = $KeepLatestCanaryN
     predicted_canary_tag = ''
     predicted_canary_core = ''
@@ -448,6 +452,9 @@ try {
         url = [string]$controlPlaneDispatch.url
         inputs = @($controlPlaneDispatch.inputs | ForEach-Object { [string]$_ })
         timestamp_utc = [string]$controlPlaneDispatch.timestamp_utc
+    }
+    if ([bool]$ForceControlPlaneWatchTimeout) {
+        throw "control_plane_watch_timeout: injected_for_drill run_id=$controlPlaneRunId timeout_minutes=$WatchTimeoutMinutes"
     }
 
     $contenderDispatchedAt = [DateTimeOffset]::MinValue

--- a/tests/ReleaseRaceHardeningDrillWorkflowContract.Tests.ps1
+++ b/tests/ReleaseRaceHardeningDrillWorkflowContract.Tests.ps1
@@ -25,6 +25,7 @@ Describe 'Release race-hardening drill workflow contract' {
         $script:workflowContent | Should -Match 'auto_remediate'
         $script:workflowContent | Should -Match 'keep_latest_canary_n'
         $script:workflowContent | Should -Match 'watch_timeout_minutes'
+        $script:workflowContent | Should -Match 'force_control_plane_watch_timeout'
     }
 
     It 'runs on hosted runner, executes drill runtime, and uploads drill + weekly summary artifacts' {
@@ -52,6 +53,7 @@ Describe 'Release race-hardening drill workflow contract' {
         $script:runtimeContent | Should -Match 'contender_dispatch_report_invalid'
         $script:runtimeContent | Should -Match 'control_plane_dispatch_report_invalid'
         $script:runtimeContent | Should -Match 'control_plane_watch_timeout'
+        $script:runtimeContent | Should -Match 'injected_for_drill'
         $script:runtimeContent | Should -Match 'contender_run_id'
         $script:runtimeContent | Should -Match 'control_plane_run_id'
         $script:runtimeContent | Should -Match 'tag_already_published_by_peer'


### PR DESCRIPTION
## Summary
- add workflow-dispatch input orce_control_plane_watch_timeout to elease-race-hardening-drill.yml
- plumb new control into Invoke-ReleaseRaceHardeningDrill.ps1
- support deterministic failure injection: control_plane_watch_timeout: injected_for_drill ...
- extend race-drill workflow contract test coverage

## Validation
- Invoke-Pester -Path ./tests/ReleaseRaceHardeningDrillWorkflowContract.Tests.ps1 -CI
- Invoke-Pester -Path ./tests/ReleaseControlPlaneWorkflowContract.Tests.ps1 -CI
- Invoke-Pester -Path ./tests -CI